### PR TITLE
Split unit tests out from build

### DIFF
--- a/codebuild/build_image.yaml
+++ b/codebuild/build_image.yaml
@@ -7,10 +7,7 @@ phases:
        # TODO: Make it polling
        - sleep 1
        # Define env variables and ECR login
-       - GO111MODULE=on 
-       # Run unit tests first
-       - (make test)
-       - (cd smlogs-kubectl-plugin && make test)
+       - GO111MODULE=on
        # Package and ship new commit version
        - (bash codebuild/scripts/package_operators.sh)
 

--- a/codebuild/unit_test.yaml
+++ b/codebuild/unit_test.yaml
@@ -1,0 +1,6 @@
+version: 0.2      
+phases:
+  build:
+    commands:
+       - (make test)
+       - (cd smlogs-kubectl-plugin && make test)


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

In order for unit tests to work in our PR system, I split the build and deploy step out from the unit test step.