### PR TITLE
Moved all integ test to EKS in us-east-1

### DIFF
--- a/tests/codebuild/run_integtest.sh
+++ b/tests/codebuild/run_integtest.sh
@@ -51,10 +51,9 @@ set -e
 if [ "${need_setup_cluster}" == "true" ]; then
     echo "Launching the cluster"
     readonly cluster_name="sagemaker-k8s-pipeline-"$(date '+%Y-%m-%d--%H-%M-%S')""
-    readonly cluster_region="us-east-1"
 
     # By default eksctl picks random AZ, which time to time leads to capacity issue.
-    eksctl create cluster "${cluster_name}" --nodes 1 --node-type=c5.xlarge --timeout=40m --region "${cluster_region}" --auto-kubeconfig --version=1.13
+    eksctl create cluster "${cluster_name}" --nodes 1 --node-type=c5.xlarge --timeout=40m --region us-east-1 --zones us-east-1a,us-east-1b,us-east-1c --auto-kubeconfig --version=1.13
 
     echo "Setting kubeconfig"
     export KUBECONFIG="/root/.kube/eksctl/clusters/${cluster_name}"


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

EKS can sometimes fail when launching in regions other than us-east-1. This will force the EKS cluster to be in specific AZs within us-east-1 only.