### PR TITLE
Disabling fsx tests as there is a configuration issue.

### DIFF
--- a/tests/codebuild/run_all_sample_test.sh
+++ b/tests/codebuild/run_all_sample_test.sh
@@ -4,7 +4,8 @@ source run_test.sh
 
 # Build prerequisite resources
 if [ "$FSX_ID" == "" ]; then
-  build_fsx_from_s3
+  echo "Skipping build_fsx_from_s3 as fsx tests are disabled"
+  #build_fsx_from_s3
 fi
 
 # TODO: Automate creation/testing of EFS file systems for relevant jobs
@@ -14,7 +15,7 @@ inject_variables testfiles/xgboost-mnist-trainingjob.yaml
 inject_variables testfiles/spot-xgboost-mnist-trainingjob.yaml
 inject_variables testfiles/xgboost-mnist-custom-endpoint.yaml
 # inject_variables testfiles/efs-xgboost-mnist-trainingjob.yaml
-inject_variables testfiles/fsx-kmeans-mnist-trainingjob.yaml
+#inject_variables testfiles/fsx-kmeans-mnist-trainingjob.yaml
 inject_variables testfiles/xgboost-mnist-hpo.yaml
 inject_variables testfiles/spot-xgboost-mnist-hpo.yaml
 inject_variables testfiles/xgboost-mnist-hpo-custom-endpoint.yaml
@@ -28,7 +29,7 @@ run_test testfiles/xgboost-mnist-trainingjob.yaml
 run_test testfiles/spot-xgboost-mnist-trainingjob.yaml
 run_test testfiles/xgboost-mnist-custom-endpoint.yaml
 # run_test testfiles/efs-xgboost-mnist-trainingjob.yaml
-run_test testfiles/fsx-kmeans-mnist-trainingjob.yaml
+#run_test testfiles/fsx-kmeans-mnist-trainingjob.yaml
 run_test testfiles/xgboost-mnist-hpo.yaml
 run_test testfiles/spot-xgboost-mnist-hpo.yaml
 run_test testfiles/xgboost-mnist-hpo-custom-endpoint.yaml
@@ -41,7 +42,7 @@ verify_test trainingjob xgboost-mnist 10m Completed
 verify_test trainingjob spot-xgboost-mnist 10m Completed
 verify_test trainingjob xgboost-mnist-custom-endpoint 10m Completed
 # verify_test trainingjob efs-xgboost-mnist 10m Completed
-verify_test trainingjob fsx-kmeans-mnist 10m Completed
+#verify_test trainingjob fsx-kmeans-mnist 10m Completed
 verify_test HyperparameterTuningJob xgboost-mnist-hpo 15m Completed
 verify_test HyperparameterTuningJob spot-xgboost-mnist-hpo 15m Completed
 verify_test HyperparameterTuningJob xgboost-mnist-hpo-custom-endpoint 15m Completed

--- a/tests/codebuild/run_test.sh
+++ b/tests/codebuild/run_test.sh
@@ -74,6 +74,7 @@ function inject_variables()
 # Build a new FSX file system for integration testing purposes
 function build_fsx_from_s3()
 {
+   echo "Building fsx from s3"
    NEW_FS=$(aws fsx create-file-system \
       --file-system-type LUSTRE \
       --lustre-configuration ImportPath=s3://${DATA_BUCKET}/kmeans_mnist_example \


### PR DESCRIPTION
Configuration issue is below. I want to get integration tests clean again, we can iterate on fsx locally later.

secondaryStatus:Failed trainingJobStatus:Failed additional:ClientError: Artifact upload failed:Please ensure that the subnet's route table has a route to an S3 VPC endpoint or a NAT device, and both the security groups and the subnet's network ACL allow outbound traffic to S3

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

