### PR TITLE
Adding bogus manager

### DIFF
--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -13,5 +13,5 @@ patchesStrategicMerge:
 # This is set by `make docker-build` but not when you build helm chart
 images:
 - name: controller
-  newName: ecr_repo/tag
+  newName: ecr_repo
   newTag: latest


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Ensures that if the image is not set during the make process that it does not, by default, use the latest production image.