### PR TITLE
Fix build pushing to prod

### DIFF
--- a/codebuild/scripts/package_operators.sh
+++ b/codebuild/scripts/package_operators.sh
@@ -70,7 +70,7 @@ function package_operator()
   fi
 
   # Only push to ECR repos if this is run on the prod pipeline
-  if [ "$PIPELINE_STAGE" == "prod" ]; then
+  if [ "$stage" == "prod" ] && [ "$PIPELINE_STAGE" == "prod" ]; then
     deploy_from_alpha "$account_id" "$account_region" "$image_repository"
   fi
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Build was pushing to prod. Build should only push to alpha, whereas deploy should push through to prod.