### PR TITLE
Allow custom subnets in canaries

### DIFF
--- a/tests/codebuild/run_canarytest.sh
+++ b/tests/codebuild/run_canarytest.sh
@@ -5,7 +5,11 @@
 # Build environment `Docker image` has all prerequisite setup and credentials are being passed using AWS system manager
 
 CLUSTER_REGION=${CLUSTER_REGION:-us-east-1}
-CLUSTER_VERSION=${CLUSTER_VERSION:-1.12}
+CLUSTER_VERSION=${CLUSTER_VERSION:-1.13}
+
+# Define the list of optional subnets for the EKS test cluster
+CLUSTER_PUBLIC_SUBNETS=${CLUSTER_PUBLIC_SUBNETS:-}
+CLUSTER_PRIVATE_SUBNETS=${CLUSTER_PRIVATE_SUBNETS:-}
 
 # Verbose trace of commands, helpful since test iteration takes a long time.
 set -x 
@@ -51,9 +55,10 @@ echo "Launching canary test for ${COMMIT_SHA}"
 echo "Launching the cluster"
 readonly cluster_name="sagemaker-k8s-pipeline-"$(date '+%Y-%m-%d-%H-%M-%S')""
 
-# By default eksctl picks random AZ, which time to time leads to  capacity issue.
-# Generally 1a, 1b, 1c are topmost available AZ, hence specifying it explicitly 
-eksctl create cluster "${cluster_name}" --nodes 1 --node-type=c5.xlarge --timeout=40m --region "${CLUSTER_REGION}" --auto-kubeconfig --version ${CLUSTER_VERSION} 
+eksctl_args=( --nodes 1 --node-type=c5.xlarge --timeout=40m --region "${CLUSTER_REGION}" --auto-kubeconfig --version "${CLUSTER_VERSION}" )
+[ "${CLUSTER_PUBLIC_SUBNETS}" != "" ] && eksctl_args+=( --vpc-public-subnets="${CLUSTER_PUBLIC_SUBNETS}" )
+[ "${CLUSTER_PRIVATE_SUBNETS}" != "" ] && eksctl_args+=( --vpc-private-subnets="${CLUSTER_PRIVATE_SUBNETS}" )
+eksctl create cluster "${cluster_name}" "${eksctl_args[@]}"
 
 echo "Setting kubeconfig"
 export KUBECONFIG="/root/.kube/eksctl/clusters/${cluster_name}"

--- a/tests/codebuild/run_canarytest.sh
+++ b/tests/codebuild/run_canarytest.sh
@@ -53,7 +53,7 @@ echo "Launching canary test for ${COMMIT_SHA}"
 
 # Launch EKS cluster if we need to and define cluster_name,CLUSTER_REGION.
 echo "Launching the cluster"
-readonly cluster_name="sagemaker-k8s-pipeline-"$(date '+%Y-%m-%d-%H-%M-%S')""
+readonly cluster_name="sagemaker-k8s-canary-"$(date '+%Y-%m-%d-%H-%M-%S')""
 
 eksctl_args=( --nodes 1 --node-type=c5.xlarge --timeout=40m --region "${CLUSTER_REGION}" --auto-kubeconfig --version "${CLUSTER_VERSION}" )
 [ "${CLUSTER_PUBLIC_SUBNETS}" != "" ] && eksctl_args+=( --vpc-public-subnets="${CLUSTER_PUBLIC_SUBNETS}" )


### PR DESCRIPTION
Creating a new EKS cluster for every canary run requires configuring a new VPC and subnets each time. Sometimes CloudFormation fails to delete the cluster CloudFormation stacks because the VPCs don't release. This meant that canaries were failing due to issues with VPC account limits. 

This CR adds the option to specify existing subnets (connected to existing VPCs) that it will pass through to `eksctl` when creating the stacks. By doing so, we are able to manage the VPCs, subnets, routing tables, internet gateways and any other VPC resources ourselves - ensuring we do not reach account limits.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.