### PR TITLE
Build integration test container programmatically

### DIFF
--- a/codebuild/build_integration_container.yaml
+++ b/codebuild/build_integration_container.yaml
@@ -1,3 +1,5 @@
+# This CodeBuild project is run using the docker:stable-dind container
+
 version: 0.2      
 phases:
   build:
@@ -5,4 +7,4 @@ phases:
        - (apk update && apk add bash)
        - (apk add --update python python-dev py-pip build-base && pip install awscli --upgrade --user)
        # Build new integration test container
-       - (IMG=$INTEGRATION_CONTAINER_REPOSITORY bash codebuild/build_deploy_integration_container.sh)
+       - (IMG=$INTEGRATION_CONTAINER_REPOSITORY bash codebuild/scripts/build_deploy_integration_container.sh)

--- a/codebuild/build_integration_container.yaml
+++ b/codebuild/build_integration_container.yaml
@@ -4,7 +4,11 @@ version: 0.2
 phases:
   build:
     commands:
-       - (apk update && apk add bash)
-       - (apk add --update python python-dev py-pip build-base && pip install awscli --upgrade)
+       # Docker engine takes few seconds to start
+       - sudo service docker start 
+       # TODO: Make it polling
+       - sleep 1
+       # Add AWSCLI and bash
+       - (apk add --update python python-dev py-pip build-base bash && pip install awscli --upgrade)
        # Build new integration test container
        - (IMG=$INTEGRATION_CONTAINER_REPOSITORY bash codebuild/scripts/build_deploy_integration_container.sh)

--- a/codebuild/build_integration_container.yaml
+++ b/codebuild/build_integration_container.yaml
@@ -1,4 +1,6 @@
 # This CodeBuild project is run using the docker:stable-dind container
+# Docker daemon start-up script was taken from the following URL:
+# https://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker-custom-image.html
 
 version: 0.2      
 phases:
@@ -6,9 +8,11 @@ phases:
     commands:
       - nohup /usr/local/bin/dockerd --host=unix:///var/run/docker.sock --host=tcp://127.0.0.1:2375 --storage-driver=overlay2&
       - timeout 15 sh -c "until docker info; do echo .; sleep 1; done"
-  build:
+  pre_build:
     commands:
        # Add AWSCLI and bash
        - (apk add --update python python-dev py-pip build-base bash && pip install awscli --upgrade)
+  build:
+    commands:
        # Build new integration test container
        - (IMG=$INTEGRATION_CONTAINER_REPOSITORY bash codebuild/scripts/build_deploy_integration_container.sh)

--- a/codebuild/build_integration_container.yaml
+++ b/codebuild/build_integration_container.yaml
@@ -5,6 +5,6 @@ phases:
   build:
     commands:
        - (apk update && apk add bash)
-       - (apk add --update python python-dev py-pip build-base && pip install awscli --upgrade --user)
+       - (apk add --update python python-dev py-pip build-base && pip install awscli --upgrade)
        # Build new integration test container
        - (IMG=$INTEGRATION_CONTAINER_REPOSITORY bash codebuild/scripts/build_deploy_integration_container.sh)

--- a/codebuild/build_integration_container.yaml
+++ b/codebuild/build_integration_container.yaml
@@ -1,0 +1,6 @@
+version: 0.2      
+phases:
+  build:
+    commands:
+       # Build new integration test container
+       - (IMG=$INTEGRATION_CONTAINER_REPOSITORY bash codebuild/build_deploy_integration_container.sh)

--- a/codebuild/build_integration_container.yaml
+++ b/codebuild/build_integration_container.yaml
@@ -2,12 +2,12 @@
 
 version: 0.2      
 phases:
+  install:
+    commands:
+      - nohup /usr/local/bin/dockerd --host=unix:///var/run/docker.sock --host=tcp://127.0.0.1:2375 --storage-driver=overlay2&
+      - timeout 15 sh -c "until docker info; do echo .; sleep 1; done"
   build:
     commands:
-       # Docker engine takes few seconds to start
-       - service docker start 
-       # TODO: Make it polling
-       - sleep 1
        # Add AWSCLI and bash
        - (apk add --update python python-dev py-pip build-base bash && pip install awscli --upgrade)
        # Build new integration test container

--- a/codebuild/build_integration_container.yaml
+++ b/codebuild/build_integration_container.yaml
@@ -2,5 +2,7 @@ version: 0.2
 phases:
   build:
     commands:
+       - (apk update && apk add bash)
+       - (apk add --update python python-dev py-pip build-base && pip install awscli --upgrade --user)
        # Build new integration test container
        - (IMG=$INTEGRATION_CONTAINER_REPOSITORY bash codebuild/build_deploy_integration_container.sh)

--- a/codebuild/build_integration_container.yaml
+++ b/codebuild/build_integration_container.yaml
@@ -5,7 +5,7 @@ phases:
   build:
     commands:
        # Docker engine takes few seconds to start
-       - sudo service docker start 
+       - service docker start 
        # TODO: Make it polling
        - sleep 1
        # Add AWSCLI and bash

--- a/codebuild/scripts/build_deploy_integration_container.sh
+++ b/codebuild/scripts/build_deploy_integration_container.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -x
+
 # Build new integration test container
 IMG=$INTEGRATION_CONTAINER_REPOSITORY bash tests/build_integration.sh
 

--- a/codebuild/scripts/build_deploy_integration_container.sh
+++ b/codebuild/scripts/build_deploy_integration_container.sh
@@ -3,7 +3,9 @@
 set -x
 
 # Build new integration test container
-IMG=$INTEGRATION_CONTAINER_REPOSITORY bash tests/build_integration.sh
+pushd tests
+IMG=$INTEGRATION_CONTAINER_REPOSITORY bash build_integration.sh
+popd
 
 # Log into ECR
 $(aws ecr get-login --no-include-email --region $REGION --registry-ids $AWS_ACCOUNT_ID)

--- a/codebuild/scripts/build_deploy_integration_container.sh
+++ b/codebuild/scripts/build_deploy_integration_container.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# This script will build the integration test container. This container contains
+# all the tools necessary for running the build and test steps for each of the
+# CodeBuild projects. The script will also tag the container with the latest
+# commit SHA, and with the "latest" tag, then push to an ECR repository.
+
 set -x
 
 # Build new integration test container

--- a/codebuild/scripts/build_deploy_integration_container.sh
+++ b/codebuild/scripts/build_deploy_integration_container.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Build new integration test container
+IMG=$INTEGRATION_CONTAINER_REPOSITORY bash tests/build_integration.sh
+
+# Log into ECR
+$(aws ecr get-login --no-include-email --region $REGION --registry-ids $AWS_ACCOUNT_ID)
+
+# Tag the container with SHA and latest
+docker tag $INTEGRATION_CONTAINER_REPOSITORY $AWS_ACCOUNT_ID.dkr.ecr.$REGION.amazonaws.com/$INTEGRATION_CONTAINER_REPOSITORY:$CODEBUILD_RESOLVED_SOURCE_VERSION
+docker tag $INTEGRATION_CONTAINER_REPOSITORY $AWS_ACCOUNT_ID.dkr.ecr.$REGION.amazonaws.com/$INTEGRATION_CONTAINER_REPOSITORY:latest
+
+# Push the newly tagged containers
+docker push $AWS_ACCOUNT_ID.dkr.ecr.$REGION.amazonaws.com/$INTEGRATION_CONTAINER_REPOSITORY:$CODEBUILD_RESOLVED_SOURCE_VERSION
+docker push $AWS_ACCOUNT_ID.dkr.ecr.$REGION.amazonaws.com/$INTEGRATION_CONTAINER_REPOSITORY:latest

--- a/tests/build_canary.sh
+++ b/tests/build_canary.sh
@@ -1,1 +1,3 @@
-docker build -f images/Dockerfile.canary . -t ${IMG} --build-arg DATA_BUCKET --build-arg COMMIT_SHA --build-arg RESULT_BUCKET
+#!/bin/bash
+
+docker build -f images/Dockerfile.canary . -t ${IMG:-canary-test-container} --build-arg DATA_BUCKET --build-arg COMMIT_SHA --build-arg RESULT_BUCKET

--- a/tests/build_integration.sh
+++ b/tests/build_integration.sh
@@ -1,1 +1,3 @@
+#!/bin/bash
+
 docker build -f images/Dockerfile.integration -t ${IMG:-integration-test-container} .

--- a/tests/build_integration.sh
+++ b/tests/build_integration.sh
@@ -1,1 +1,1 @@
-docker build -f images/Dockerfile.integration -t integration-test-container .
+docker build -f images/Dockerfile.integration -t ${IMG:-integration-test-container} .


### PR DESCRIPTION
This PR creates a new CodeBuild specification which uses the `docker:stable-dind` container to build and push the integration test container to a specified ECR repository. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.