### PR TITLE
Updating v1.0 installer image to ECR v1.0 tag

### DIFF
--- a/release/rolebased/installer.yaml
+++ b/release/rolebased/installer.yaml
@@ -4011,7 +4011,7 @@ spec:
         env:
         - name: AWS_DEFAULT_SAGEMAKER_ENDPOINT
           value: ""
-        image: 957583890962.dkr.ecr.us-east-1.amazonaws.com/amazon-sagemaker-operator-for-k8s:latest
+        image: 957583890962.dkr.ecr.us-east-1.amazonaws.com/amazon-sagemaker-operator-for-k8s:v1.0
         imagePullPolicy: Always
         name: manager
         resources:


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

I tested this by deploying it to my cluster. I created a TrainingJob and everything worked as expected.

@RedbackThomson I ran into troubles updating the v1.0 branch because it is the same name as the tag, can we switch to use `r1.0` for branches and `v1.0` for tags?  This is how [Tensorflow](https://github.com/tensorflow/tensorflow/branches) does it.