### PR TITLE
Fixing HPO/BT deletion resource leak when SageMaker throttles Describe 

### DIFF
--- a/controllers/batchtransformjob/batchtransformjob_controller_test.go
+++ b/controllers/batchtransformjob/batchtransformjob_controller_test.go
@@ -444,6 +444,34 @@ var _ = Describe("Reconciling a job with finalizer that is being deleted", func(
 		Expect(job.Status.TransformJobStatus).To(ContainSubstring(string(sagemaker.TransformJobStatusStopping)))
 	})
 
+	It("should update the status and retry if SageMaker throttles", func() {
+		rateExceededMessage := "Rate exceeded"
+		// Setup mock responses.
+		sageMakerClient := builder.
+			AddDescribeTransformJobErrorResponse("ThrottlingException", 400, "request id", rateExceededMessage).
+			Build()
+
+		// Instantiate controller and reconciliation request.
+		controller := createTransformJobReconcilerForSageMakerClient(k8sClient, sageMakerClient, 1)
+		request := CreateReconciliationRequest(job.ObjectMeta.Name, job.ObjectMeta.Namespace)
+
+		// Run test and verify expectations.
+		reconciliationResult, err := controller.Reconcile(request)
+
+		Expect(receivedRequests.Len()).To(Equal(1))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(reconciliationResult.Requeue).To(Equal(false))
+		Expect(reconciliationResult.RequeueAfter).To(Equal(controller.PollInterval))
+
+		// Verify status is updated.
+		err = k8sClient.Get(context.Background(), types.NamespacedName{
+			Namespace: job.ObjectMeta.Namespace,
+			Name:      job.ObjectMeta.Name,
+		}, job)
+
+		Expect(job.Status.Additional).To(ContainSubstring(rateExceededMessage))
+	})
+
 	It("should remove the finalizer and not requeue if the job is stopped", func() {
 		description.TransformJobStatus = sagemaker.TransformJobStatusStopped
 		// Setup mock responses.

--- a/controllers/controllertest/mock_sagemaker_client.go
+++ b/controllers/controllertest/mock_sagemaker_client.go
@@ -274,9 +274,9 @@ func (m *MockSageMakerClientBuilder) AddDescribeEndpointErrorResponse(code strin
 }
 
 // Add a DescribeTrainingJob error response to the client.
-func (m *MockSageMakerClientBuilder) AddDescribeTransformJobErrorResponse(code string, statusCode int, reqId string) *MockSageMakerClientBuilder {
+func (m *MockSageMakerClientBuilder) AddDescribeTransformJobErrorResponse(code string, statusCode int, reqId, message string) *MockSageMakerClientBuilder {
 	m.responses.PushBack(describeTransformJobResponse{
-		err:  awserr.NewRequestFailure(awserr.New(code, "mock error message", fmt.Errorf(code)), statusCode, reqId),
+		err:  awserr.NewRequestFailure(awserr.New(code, message, fmt.Errorf(code)), statusCode, reqId),
 		data: nil,
 	})
 	return m


### PR DESCRIPTION
* The fix here is not clean; the delete portion of the code needs to be refactored.
* I added a unit test for each fix.
* I verified the fix by setting up nginx proxy to throttle 100% of requests, then I deleted the resources. Before my fix, they were leaked, after my change, the operator waits and deletes the Kubernetes resource after the SageMaker resource has been stopped.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.