### PR TITLE
Fixing the log message in canary run test

### DIFF
--- a/tests/codebuild/run_canarytest.sh
+++ b/tests/codebuild/run_canarytest.sh
@@ -39,7 +39,7 @@ function cleanup {
     if [ -z "${USE_EXISTING_CLUSTER}" ]
     then
         # Tear down the cluster if we set it up.
-        echo "USE_EXISTING_CLUSTER is true, tearing down cluster we created."
+        echo "USE_EXISTING_CLUSTER is false, tearing down cluster we created."
         eksctl delete cluster --name "${cluster_name}" --region "${CLUSTER_REGION}"
     fi
 }


### PR DESCRIPTION
Fixing the log message in canary run test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

