### PR TITLE
Fixing the path for testsfiles in canary and integ tests

### DIFF
--- a/samples/xgboost-mnist-batchtransform.yaml
+++ b/samples/xgboost-mnist-batchtransform.yaml
@@ -1,7 +1,7 @@
 apiVersion: sagemaker.aws.amazon.com/v1
 kind: BatchTransformJob
 metadata:
-  name: xgboost-mnist
+  name: xgboost-batch
 spec:
   region: us-west-2
   modelName: sagemaker-tensorflow-model

--- a/tests/codebuild/run_all_sample_canary_tests.sh
+++ b/tests/codebuild/run_all_sample_canary_tests.sh
@@ -6,17 +6,22 @@ source run_test.sh
 # Inject environment variables into tests
 inject_variables tests/xgboost-mnist-trainingjob.yaml
 inject_variables tests/xgboost-mnist-hpo.yaml
-inject_variables testfiles/xgboost-model.yaml
+inject_variables tests/xgboost-model.yaml
 inject_variables tests/xgboost-mnist-batchtransform.yaml 
 inject_variables tests/xgboost-hosting-deployment.yaml
 
 # Add all your new sample files below
 # Run test
-# Format: `run_test testfiles/<Your test file name>`
+# Format: `run_test tests/<Your test file name>`
 run_test tests/xgboost-mnist-trainingjob.yaml
 run_test tests/xgboost-mnist-hpo.yaml
-run_test testfiles/xgboost-model.yaml
-run_batch_transform_test
+run_test tests/xgboost-model.yaml
+# Special code for batch transform till we fix issue-59
+run_test tests/xgboost-model.yaml
+# We need to get sagemaker model before running batch transform
+verify_test Model xgboost-model 1m Created
+sed -i "s/xgboost-model/$(get_sagemaker_model_from_k8s_model xgboost-model)/g" tests/xgboost-mnist-batchtransform.yaml
+run_test tests/xgboost-mnist-batchtransform.yaml 
 run_test tests/xgboost-hosting-deployment.yaml
 
 # Verify test

--- a/tests/codebuild/run_all_sample_test.sh
+++ b/tests/codebuild/run_all_sample_test.sh
@@ -35,7 +35,12 @@ run_test testfiles/xgboost-mnist-hpo.yaml
 run_test testfiles/spot-xgboost-mnist-hpo.yaml
 run_test testfiles/xgboost-mnist-hpo-custom-endpoint.yaml
 run_test testfiles/xgboost-model.yaml
-run_batch_transform_test
+# Special function for batch transform till we fix issue-59
+run_test testfiles/xgboost-model.yaml
+# We need to get sagemaker model before running batch transform
+verify_test Model xgboost-model 1m Created
+sed -i "s/xgboost-model/$(get_sagemaker_model_from_k8s_model xgboost-model)/g" testfiles/xgboost-mnist-batchtransform.yaml
+run_test testfiles/xgboost-mnist-batchtransform.yaml 
 run_test testfiles/xgboost-hosting-deployment.yaml
 
 # Verify test
@@ -48,7 +53,7 @@ verify_test trainingjob xgboost-mnist-custom-endpoint 20m Completed
 verify_test HyperparameterTuningJob xgboost-mnist-hpo 20m Completed
 verify_test HyperparameterTuningJob spot-xgboost-mnist-hpo 20m Completed
 verify_test HyperparameterTuningJob xgboost-mnist-hpo-custom-endpoint 20m Completed
-verify_test BatchTransformJob xgboost-mnist 20m Completed
+verify_test BatchTransformJob xgboost-batch 20m Completed
 verify_test HostingDeployment hosting 40m InService
 
 # Verify smlogs worked.

--- a/tests/codebuild/run_test.sh
+++ b/tests/codebuild/run_test.sh
@@ -112,12 +112,3 @@ function build_fsx_from_s3()
 
    export FSX_ID=$FSX_ID
 }
-
-# Special function for batch transform till we fix issue-59
-function run_batch_transform_test() {
-    run_test testfiles/xgboost-model.yaml
-    # We need to get sagemaker model before running batch transform
-    verify_test Model xgboost-model 1m Created
-    sed -i "s/xgboost-model/$(get_sagemaker_model_from_k8s_model xgboost-model)/g" testfiles/xgboost-mnist-batchtransform.yaml
-    run_test tests/xgboost-mnist-batchtransform.yaml 
-}


### PR DESCRIPTION
Canary tests assumes that files are in tests dir,
while integ tests assumes that files are in testsfiles.
For Batch Transform tests I've fixed this path, eventually we should have same path for both tests. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

