### PR TITLE
Fixed incorrect canary batch name

### DIFF
--- a/tests/codebuild/run_all_sample_canary_tests.sh
+++ b/tests/codebuild/run_all_sample_canary_tests.sh
@@ -28,7 +28,7 @@ run_test tests/xgboost-hosting-deployment.yaml
 # Format: `verify_test <type of job> <Job's metadata name> <timeout to complete the test> <desired status for job to achieve>` 
 verify_test TrainingJob xgboost-mnist 20m Completed
 verify_test HyperparameterTuningJob xgboost-mnist-hpo 20m Completed
-verify_test BatchTransformJob xgboost-mnist 20m Completed 
+verify_test BatchTransformJob xgboost-batch 20m Completed 
 verify_test HostingDeployment hosting 40m InService
 
 # Verify smlogs worked.


### PR DESCRIPTION
Canary test was still referencing the old batch transform test metadata name. Updated to fit the new name `xgboost-batch`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

