### PR TITLE
Removing flakey wait from canaries

### DIFF
--- a/tests/codebuild/run_canarytest.sh
+++ b/tests/codebuild/run_canarytest.sh
@@ -99,7 +99,7 @@ popd
 
 echo "Waiting for controller pod to be Ready"
 # Wait to increase chance that pod is ready
-# Should upgrade kubectl to version that supports `kubectl wait pods --all`
+# TODO: Should upgrade kubectl to version that supports `kubectl wait pods --all`
 sleep 60
 
 # Run the integration test file

--- a/tests/codebuild/run_canarytest.sh
+++ b/tests/codebuild/run_canarytest.sh
@@ -98,12 +98,9 @@ pushd sagemaker-k8s-operator
 popd 
 
 echo "Waiting for controller pod to be Ready"
-kubectl \
-    wait \
-    --for=condition=Ready \
-    --timeout=5m \
-    "pods/$(kubectl get pods -n sagemaker-k8s-operator-system | grep sagemaker-k8s-operator-controller-manager | awk '{print $1}')" \
-    -n sagemaker-k8s-operator-system 
+# Wait to increase chance that pod is ready
+# Should upgrade kubectl to version that supports `kubectl wait pods --all`
+sleep 60
 
 # Run the integration test file
 ./run_all_sample_canary_tests.sh

--- a/tests/codebuild/run_integtest.sh
+++ b/tests/codebuild/run_integtest.sh
@@ -113,7 +113,7 @@ popd
 
 echo "Waiting for controller pod to be Ready"
 # Wait to increase chance that pod is ready
-# Should upgrade kubectl to version that supports `kubectl wait pods --all`
+# TODO: Should upgrade kubectl to version that supports `kubectl wait pods --all`
 sleep 60
 
 # TODO: Add Helm chart tests


### PR DESCRIPTION
Canaries failed with the following:

```
+ kubectl wait --for=condition=Ready --timeout=5m 'pods/sagemaker-k8s-operator-controller-manager-9f488df7f-qjslx
sagemaker-k8s-operator-controller-manager-dfb5c5bb7-nhv57' -n sagemaker-k8s-operator-system
Error from server (NotFound): pods "sagemaker-k8s-operator-controller-manager-9f488df7f-qjslx\nsagemaker-k8s-operator-controller-manager-dfb5c5bb7-nhv57" not found
```

This is because the canaries have a wait command that used to be in the integration tests, but was removed for its flakiness.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.