### PR TITLE
Remove the https reference from s3 paths

### DIFF
--- a/samples/efs-xgboost-mnist-trainingjob.yaml
+++ b/samples/efs-xgboost-mnist-trainingjob.yaml
@@ -26,7 +26,7 @@ spec:
     roleArn: arn:aws:iam::123456789012:role/service-role/AmazonSageMaker-ExecutionRole
     region: us-west-2
     outputDataConfig:
-        s3OutputPath: https://s3-us-west-2.amazonaws.com/my-bucket/xgboost
+        s3OutputPath: s3://my-bucket/xgboost
     resourceConfig:
         instanceCount: 1
         instanceType: ml.m4.xlarge

--- a/samples/spot-xgboost-mnist-hpo.yaml
+++ b/samples/spot-xgboost-mnist-hpo.yaml
@@ -82,7 +82,7 @@ spec:
         dataSource:
           s3DataSource:
             s3DataType: S3Prefix
-            s3Uri: https://s3-us-west-2.amazonaws.com/my-bucket/xgboost/train/
+            s3Uri: s3://my-bucket/xgboost/train/
             s3DataDistributionType: FullyReplicated
         contentType: text/csv
         compressionType: None
@@ -92,14 +92,14 @@ spec:
         dataSource:
           s3DataSource:
             s3DataType: S3Prefix
-            s3Uri: https://s3-us-west-2.amazonaws.com/my-bucket/xgboost/validation/
+            s3Uri: s3://my-bucket/xgboost/validation/
             s3DataDistributionType: FullyReplicated
         contentType: text/csv
         compressionType: None
         recordWrapperType: None
         inputMode: File
       outputDataConfig:
-        s3OutputPath: https://s3-us-west-2.amazonaws.com/my-bucket/xgboost
+        s3OutputPath: s3://my-bucket/xgboost
       resourceConfig:
         instanceType: ml.m4.xlarge
         instanceCount: 1
@@ -111,4 +111,4 @@ spec:
       enableNetworkIsolation: true
       enableInterContainerTrafficEncryption: false
       checkpointConfig:
-        s3Uri: https://s3-us-west-2.amazonaws.com/my-bucket/xgboost/checkpoints/
+        s3Uri: s3://my-bucket/xgboost/checkpoints/

--- a/samples/spot-xgboost-mnist-trainingjob.yaml
+++ b/samples/spot-xgboost-mnist-trainingjob.yaml
@@ -26,7 +26,7 @@ spec:
     roleArn: arn:aws:iam::123456789012:role/service-role/AmazonSageMaker-ExecutionRole
     region: us-west-2
     outputDataConfig:
-        s3OutputPath: https://s3-us-west-2.amazonaws.com/my-bucket/xgboost
+        s3OutputPath: s3://my-bucket/xgboost
     resourceConfig:
         instanceCount: 1
         instanceType: ml.m4.xlarge
@@ -40,7 +40,7 @@ spec:
           dataSource:
             s3DataSource:
                 s3DataType: S3Prefix
-                s3Uri: https://s3-us-west-2.amazonaws.com/my-bucket/xgboost/train/
+                s3Uri: s3://my-bucket/xgboost/train/
                 s3DataDistributionType: FullyReplicated
           contentType: text/csv
           compressionType: None
@@ -48,9 +48,9 @@ spec:
           dataSource:
             s3DataSource:
                 s3DataType: S3Prefix
-                s3Uri: https://s3-us-west-2.amazonaws.com/my-bucket/xgboost/validation/
+                s3Uri: s3://my-bucket/xgboost/validation/
                 s3DataDistributionType: FullyReplicated
           contentType: text/csv
           compressionType: None
     checkpointConfig:
-       s3Uri: https://s3-us-west-2.amazonaws.com/my-bucket/xgboost/checkpoints/
+       s3Uri: s3://my-bucket/xgboost/checkpoints/

--- a/samples/xgboost-mnist-custom-endpoint.yaml
+++ b/samples/xgboost-mnist-custom-endpoint.yaml
@@ -27,7 +27,7 @@ spec:
     region: us-west-2
     sageMakerEndpoint: https://sagemaker.us-west-2.amazonaws.com
     outputDataConfig:
-        s3OutputPath: https://s3-us-west-2.amazonaws.com/my-bucket/xgboost
+        s3OutputPath: s3://my-bucket/xgboost
     resourceConfig:
         instanceCount: 1
         instanceType: ml.m4.xlarge
@@ -39,7 +39,7 @@ spec:
           dataSource:
             s3DataSource:
                 s3DataType: S3Prefix
-                s3Uri: https://s3-us-west-2.amazonaws.com/my-bucket/xgboost/train/
+                s3Uri: s3://my-bucket/xgboost/train/
                 s3DataDistributionType: FullyReplicated
           contentType: text/csv
           compressionType: None
@@ -47,7 +47,7 @@ spec:
           dataSource:
             s3DataSource:
                 s3DataType: S3Prefix
-                s3Uri: https://s3-us-west-2.amazonaws.com/my-bucket/xgboost/validation/
+                s3Uri: s3://my-bucket/xgboost/validation/
                 s3DataDistributionType: FullyReplicated
           contentType: text/csv
           compressionType: None

--- a/samples/xgboost-mnist-hpo-custom-endpoint.yaml
+++ b/samples/xgboost-mnist-hpo-custom-endpoint.yaml
@@ -79,7 +79,7 @@ spec:
         dataSource:
           s3DataSource:
             s3DataType: S3Prefix
-            s3Uri: https://s3-us-west-2.amazonaws.com/my-bucket/xgboost/train/
+            s3Uri: s3://my-bucket/xgboost/train/
             s3DataDistributionType: FullyReplicated
         contentType: text/csv
         compressionType: None
@@ -89,14 +89,14 @@ spec:
         dataSource:
           s3DataSource:
             s3DataType: S3Prefix
-            s3Uri: https://s3-us-west-2.amazonaws.com/my-bucket/xgboost/validation/
+            s3Uri: s3://my-bucket/xgboost/validation/
             s3DataDistributionType: FullyReplicated
         contentType: text/csv
         compressionType: None
         recordWrapperType: None
         inputMode: File
       outputDataConfig:
-        s3OutputPath: https://s3-us-west-2.amazonaws.com/my-bucket/xgboost
+        s3OutputPath: s3://my-bucket/xgboost
       resourceConfig:
         instanceType: ml.m4.xlarge
         instanceCount: 1

--- a/samples/xgboost-mnist-hpo.yaml
+++ b/samples/xgboost-mnist-hpo.yaml
@@ -86,7 +86,7 @@ spec:
         dataSource:
           s3DataSource:
             s3DataType: S3Prefix
-            s3Uri: https://s3-us-west-2.amazonaws.com/my-bucket/xgboost/train/
+            s3Uri: s3://my-bucket/xgboost/train/
             s3DataDistributionType: FullyReplicated
         contentType: text/csv
         compressionType: None
@@ -96,14 +96,14 @@ spec:
         dataSource:
           s3DataSource:
             s3DataType: S3Prefix
-            s3Uri: https://s3-us-west-2.amazonaws.com/my-bucket/xgboost/validation/
+            s3Uri: s3://my-bucket/xgboost/validation/
             s3DataDistributionType: FullyReplicated
         contentType: text/csv
         compressionType: None
         recordWrapperType: None
         inputMode: File
       outputDataConfig:
-        s3OutputPath: https://s3-us-west-2.amazonaws.com/my-bucket/xgboost
+        s3OutputPath: s3://my-bucket/xgboost
       resourceConfig:
         instanceType: ml.m4.xlarge
         instanceCount: 1

--- a/samples/xgboost-mnist-trainingjob.yaml
+++ b/samples/xgboost-mnist-trainingjob.yaml
@@ -38,7 +38,7 @@ spec:
           dataSource:
             s3DataSource:
                 s3DataType: S3Prefix
-                s3Uri: https://s3-us-west-2.amazonaws.com/my-bucket/xgboost/train/
+                s3Uri: s3://my-bucket/xgboost/train/
                 s3DataDistributionType: FullyReplicated
           contentType: text/csv
           compressionType: None
@@ -46,7 +46,7 @@ spec:
           dataSource:
             s3DataSource:
                 s3DataType: S3Prefix
-                s3Uri: https://s3-us-west-2.amazonaws.com/my-bucket/xgboost/validation/
+                s3Uri: s3://my-bucket/xgboost/validation/
                 s3DataDistributionType: FullyReplicated
           contentType: text/csv
           compressionType: None


### PR DESCRIPTION
This came during one of the feedback from Arun Gupta 

"Change samples to use s3:// by default instead of https. This came up when he was changing regions, and asked if he had to change them for all https URLs." 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

