### PR TITLE
Increase batch transform test timeouts

### DIFF
--- a/tests/codebuild/run_all_sample_canary_tests.sh
+++ b/tests/codebuild/run_all_sample_canary_tests.sh
@@ -28,7 +28,7 @@ run_test tests/xgboost-hosting-deployment.yaml
 # Format: `verify_test <type of job> <Job's metadata name> <timeout to complete the test> <desired status for job to achieve>` 
 verify_test TrainingJob xgboost-mnist 20m Completed
 verify_test HyperparameterTuningJob xgboost-mnist-hpo 20m Completed
-verify_test BatchTransformJob xgboost-batch 20m Completed 
+verify_test BatchTransformJob xgboost-batch 30m Completed
 verify_test HostingDeployment hosting 40m InService
 
 # Verify smlogs worked.

--- a/tests/codebuild/run_all_sample_test.sh
+++ b/tests/codebuild/run_all_sample_test.sh
@@ -53,7 +53,7 @@ verify_test trainingjob xgboost-mnist-custom-endpoint 20m Completed
 verify_test HyperparameterTuningJob xgboost-mnist-hpo 20m Completed
 verify_test HyperparameterTuningJob spot-xgboost-mnist-hpo 20m Completed
 verify_test HyperparameterTuningJob xgboost-mnist-hpo-custom-endpoint 20m Completed
-verify_test BatchTransformJob xgboost-batch 20m Completed
+verify_test BatchTransformJob xgboost-batch 30m Completed
 verify_test HostingDeployment hosting 40m InService
 
 # Verify smlogs worked.


### PR DESCRIPTION
Canaries failed because BT took 23 minutes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

