### PR TITLE
Fix broken canary container Dockerfile

### DIFF
--- a/tests/images/Dockerfile.canary
+++ b/tests/images/Dockerfile.canary
@@ -7,11 +7,11 @@ RUN apt-get update && apt-get install -y curl \
     python-pip \
     vim \
     sudo
-
+    
 RUN pip install awscli
 
 # Install yq
-RUN sudo add-apt-repository ppa:rmescandon/yq && apt update && apt install -y yq
+RUN apt-get update && apt install -y apt-transport-https ca-certificates curl gnupg-agent software-properties-common && sudo add-apt-repository ppa:rmescandon/yq && apt update && apt install -y yq
 
 # Install kubectl
 RUN curl -o kubectl https://amazon-eks.s3-us-west-2.amazonaws.com/1.12.9/2019-06-21/bin/linux/amd64/kubectl \

--- a/tests/images/Dockerfile.canary
+++ b/tests/images/Dockerfile.canary
@@ -10,8 +10,8 @@ RUN apt-get update && apt-get install -y curl \
 
 RUN pip install awscli
 
-# Install yq
-RUN apt-get update && apt install -y apt-transport-https ca-certificates curl gnupg-agent software-properties-common && sudo add-apt-repository ppa:rmescandon/yq && apt update && apt install -y yq
+# Add yq repository and install yq
+RUN apt-get update && apt install -y software-properties-common && sudo add-apt-repository ppa:rmescandon/yq && apt update && apt install -y yq
 
 # Install kubectl
 RUN curl -o kubectl https://amazon-eks.s3-us-west-2.amazonaws.com/1.12.9/2019-06-21/bin/linux/amd64/kubectl \

--- a/tests/images/Dockerfile.canary
+++ b/tests/images/Dockerfile.canary
@@ -7,7 +7,7 @@ RUN apt-get update && apt-get install -y curl \
     python-pip \
     vim \
     sudo
-    
+
 RUN pip install awscli
 
 # Install yq


### PR DESCRIPTION
The canary Dockerfile was failing due to the necessary `software-properties-common` package not being installed before calling `add-apt-repository`. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

