### PR TITLE
Fix canary missing scripts

### DIFF
--- a/tests/images/Dockerfile.canary
+++ b/tests/images/Dockerfile.canary
@@ -46,21 +46,12 @@ ENV RESULT_BUCKET=$RESULT_BUCKET
 RUN mkdir -p /app/testfiles
 WORKDIR /app/testfiles
 
-COPY codebuild/testfiles/xgboost-mnist-hpo.yaml .
-COPY codebuild/testfiles/xgboost-mnist-trainingjob.yaml .
-COPY codebuild/testfiles/xgboost-mnist-batchtransform.yaml .
-COPY codebuild/testfiles/xgboost-hosting-deployment.yaml .
-COPY codebuild/testfiles/xgboost-model.yaml .
+COPY codebuild/testfiles/*.yaml ./
 
 WORKDIR /app
 
-COPY codebuild/run_all_sample_canary_tests.sh .
-COPY codebuild/run_canarytest.sh .
-COPY codebuild/run_test.sh .
-
-RUN chmod +x ./run_all_sample_canary_tests.sh
-RUN chmod +x ./run_canarytest.sh
-RUN chmod +x ./run_test.sh
+COPY codebuild/*.sh ./
+RUN chmod +x ./*.sh
 
 COPY sagemaker-k8s-operator.tar.gz .
 

--- a/tests/images/Dockerfile.canary
+++ b/tests/images/Dockerfile.canary
@@ -7,11 +7,11 @@ RUN apt-get update && apt-get install -y curl \
     python-pip \
     vim \
     sudo
-
+    
 RUN pip install awscli
 
 # Install yq
-RUN sudo add-apt-repository ppa:rmescandon/yq && apt update && apt install -y yq
+RUN apt-get update && apt install -y apt-transport-https ca-certificates curl gnupg-agent software-properties-common && sudo add-apt-repository ppa:rmescandon/yq && apt update && apt install -y yq
 
 # Install kubectl
 RUN curl -o kubectl https://amazon-eks.s3-us-west-2.amazonaws.com/1.12.9/2019-06-21/bin/linux/amd64/kubectl \

--- a/tests/images/Dockerfile.canary
+++ b/tests/images/Dockerfile.canary
@@ -10,8 +10,8 @@ RUN apt-get update && apt-get install -y curl \
 
 RUN pip install awscli
 
-# Install yq
-RUN apt-get update && apt install -y apt-transport-https ca-certificates curl gnupg-agent software-properties-common && sudo add-apt-repository ppa:rmescandon/yq && apt update && apt install -y yq
+# Add yq repository and install yq
+RUN apt-get update && apt install -y software-properties-common && sudo add-apt-repository ppa:rmescandon/yq && apt update && apt install -y yq
 
 # Install kubectl
 RUN curl -o kubectl https://amazon-eks.s3-us-west-2.amazonaws.com/1.12.9/2019-06-21/bin/linux/amd64/kubectl \

--- a/tests/images/Dockerfile.canary
+++ b/tests/images/Dockerfile.canary
@@ -7,7 +7,7 @@ RUN apt-get update && apt-get install -y curl \
     python-pip \
     vim \
     sudo
-    
+
 RUN pip install awscli
 
 # Install yq


### PR DESCRIPTION
The canary container Dockerfile was using old references to shell scripts that were renamed in the last refactor. This adds all scripts back into the container.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

