### PR TITLE
Added jq to canary container

### DIFF
--- a/tests/images/Dockerfile.canary
+++ b/tests/images/Dockerfile.canary
@@ -6,7 +6,8 @@ RUN apt-get update && apt-get install -y curl \
     python \
     python-pip \
     vim \
-    sudo
+    sudo \
+    jq
 
 RUN pip install awscli
 


### PR DESCRIPTION
We need a better way to test the canary container. At the moment I have to manually create a tarball to use as the install scripts (needs to be changed to helm charts and OIDC anyway), and then configure some values that only I know exist - some at runtime and some at build time.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

