### PR TITLE
Modified canary common.sh source path

### DIFF
--- a/tests/codebuild/run_canarytest.sh
+++ b/tests/codebuild/run_canarytest.sh
@@ -1,18 +1,5 @@
 #!/bin/bash
 
-source ./common.sh
-
-# TODOs
-# 1. Add validation for each steps and abort the test if steps fails
-# Build environment `Docker image` has all prerequisite setup and credentials are being passed using AWS system manager
-
-CLUSTER_REGION=${CLUSTER_REGION:-us-east-1}
-CLUSTER_VERSION=${CLUSTER_VERSION:-1.13}
-
-# Define the list of optional subnets for the EKS test cluster
-CLUSTER_PUBLIC_SUBNETS=${CLUSTER_PUBLIC_SUBNETS:-}
-CLUSTER_PRIVATE_SUBNETS=${CLUSTER_PRIVATE_SUBNETS:-}
-
 # Verbose trace of commands, helpful since test iteration takes a long time.
 set -x 
 
@@ -44,6 +31,19 @@ trap cleanup EXIT
 
 # If any command fails, exit the script with an error code.
 set -e
+
+source ./common.sh
+
+# TODOs
+# 1. Add validation for each steps and abort the test if steps fails
+# Build environment `Docker image` has all prerequisite setup and credentials are being passed using AWS system manager
+
+CLUSTER_REGION=${CLUSTER_REGION:-us-east-1}
+CLUSTER_VERSION=${CLUSTER_VERSION:-1.13}
+
+# Define the list of optional subnets for the EKS test cluster
+CLUSTER_PUBLIC_SUBNETS=${CLUSTER_PUBLIC_SUBNETS:-}
+CLUSTER_PRIVATE_SUBNETS=${CLUSTER_PRIVATE_SUBNETS:-}
 
 # Output the commit SHA for logging sake
 echo "Launching canary test for ${COMMIT_SHA}"

--- a/tests/codebuild/run_canarytest.sh
+++ b/tests/codebuild/run_canarytest.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source tests/codebuild/common.sh
+source ./common.sh
 
 # TODOs
 # 1. Add validation for each steps and abort the test if steps fails


### PR DESCRIPTION
Considering the current directory context is different between the integration test and the canary test, the source was only correct for the integration tests. I have modified the path of the `source common.sh` to relatively import the file, since `run_canarytest.sh` is activated in the same directory.

I have tested this change by running the container on my local machine and ensuring it is able to run the `delete_all_resources` method.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.