### PR TITLE
Update Training job Status and Spec

### DIFF
--- a/controllers/controllertest/k8s_mocks.go
+++ b/controllers/controllertest/k8s_mocks.go
@@ -97,14 +97,28 @@ type FailToUpdateK8sClient struct {
 	ActualClient client.Client
 }
 
+type FailToUpdateK8sStatusWriter struct {
+	client.StatusWriter
+}
+
 // Get should work normally.
 func (m FailToUpdateK8sClient) Get(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
 	return m.ActualClient.Get(ctx, key, obj)
 }
 
-// Always return error on Update.
+// Update should always return error on Update.
 func (m FailToUpdateK8sClient) Update(_ context.Context, _ runtime.Object, _ ...client.UpdateOption) error {
 	return fmt.Errorf("unable to Update")
+}
+
+// Status should always return a mock status writer with Update patched.
+func (m FailToUpdateK8sClient) Status() client.StatusWriter {
+	return &FailToUpdateK8sStatusWriter{}
+}
+
+// Update should always return an error.
+func (m FailToUpdateK8sStatusWriter) Update(_ context.Context, _ runtime.Object, _ ...client.UpdateOption) error {
+	return fmt.Errorf("unable to update status")
 }
 
 // Mock of Kubernetes client.Client that always returns error when Create is invoked.

--- a/controllers/trainingjob/trainingjob_controller.go
+++ b/controllers/trainingjob/trainingjob_controller.go
@@ -245,12 +245,6 @@ func (r *Reconciler) initializeContext(ctx *reconcileRequestContext) error {
 func (r *Reconciler) initializeTrainingJobName(ctx *reconcileRequestContext) error {
 	ctx.TrainingJob.Spec.TrainingJobName = &ctx.TrainingJobName
 
-	ctx.TrainingJob.Status.SageMakerTrainingJobName = ctx.TrainingJobName
-	//TODO: Convert it to tinyurl or even better can we expose CW url via API server proxy UI?
-	ctx.TrainingJob.Status.CloudWatchLogUrl = "https://" + *ctx.TrainingJob.Spec.Region + ".console.aws.amazon.com/cloudwatch/home?region=" +
-		*ctx.TrainingJob.Spec.Region + "#logStream:group=/aws/sagemaker/TrainingJobs;prefix=" +
-		ctx.TrainingJobName + ";streamFilter=typeLogStreamPrefix"
-
 	if err := r.Status().Update(ctx, ctx.TrainingJob); err != nil {
 		ctx.Log.Error(err, "Error while updating training job name")
 		return err
@@ -330,6 +324,12 @@ func (r *Reconciler) updateStatusWithAdditional(ctx reconcileRequestContext, tra
 	jobStatus.TrainingJobStatus = trainingJobPrimaryStatus
 	jobStatus.SecondaryStatus = trainingJobSecondaryStatus
 	jobStatus.Additional = additional
+
+	jobStatus.SageMakerTrainingJobName = ctx.TrainingJobName
+	//TODO: Convert it to tinyurl or even better can we expose CW url via API server proxy UI?
+	jobStatus.CloudWatchLogUrl = "https://" + *ctx.TrainingJob.Spec.Region + ".console.aws.amazon.com/cloudwatch/home?region=" +
+		*ctx.TrainingJob.Spec.Region + "#logStream:group=/aws/sagemaker/TrainingJobs;prefix=" +
+		ctx.TrainingJobName + ";streamFilter=typeLogStreamPrefix"
 
 	if err := r.Status().Update(ctx, ctx.TrainingJob); err != nil {
 		err = errors.Wrap(err, "Unable to update status")

--- a/controllers/trainingjob/trainingjob_controller.go
+++ b/controllers/trainingjob/trainingjob_controller.go
@@ -226,6 +226,7 @@ func (r *Reconciler) initializeContext(ctx *reconcileRequestContext) error {
 		ctx.TrainingJobName = *ctx.TrainingJob.Spec.TrainingJobName
 	} else {
 		ctx.TrainingJobName = controllers.GetGeneratedJobName(ctx.TrainingJob.ObjectMeta.GetUID(), ctx.TrainingJob.ObjectMeta.GetName(), MaxTrainingJobNameLength)
+		ctx.TrainingJob.Spec.TrainingJobName = &ctx.TrainingJobName
 	}
 	ctx.Log.Info("TrainingJob", "name", ctx.TrainingJobName)
 
@@ -308,6 +309,9 @@ func (r *Reconciler) updateStatusWithAdditional(ctx reconcileRequestContext, tra
 	ctx.Log.Info("updateStatusWithAdditional", "trainingJobPrimaryStatus", trainingJobPrimaryStatus, "trainingJobSecondaryStatus", trainingJobSecondaryStatus, "additional", additional)
 
 	jobStatus := &ctx.TrainingJob.Status
+
+	jobStatus.SageMakerTrainingJobName = ctx.TrainingJobName
+
 	// When you call this function, update/refresh all the fields since we overwrite.
 	jobStatus.TrainingJobStatus = trainingJobPrimaryStatus
 	jobStatus.SecondaryStatus = trainingJobSecondaryStatus

--- a/controllers/trainingjob/trainingjob_controller_test.go
+++ b/controllers/trainingjob/trainingjob_controller_test.go
@@ -165,7 +165,7 @@ var _ = Describe("Reconciling a TrainingJob that exists", func() {
 		})
 	})
 
-	Context("K8s client fails to update", func() {
+	Context("K8s client fails to update generated spec name", func() {
 		BeforeEach(func() {
 			kubernetesClient = FailToUpdateK8sClient{ActualClient: kubernetesClient}
 


### PR DESCRIPTION
In the `smlogs` code, we reference the training job name from the spec. The training job name was not being updated in the spec or in the status. This is not caught in unit tests because it tests interoperability between smlogs and the controller.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

