### PR TITLE
Deduplicate the logic for resource name generation

### DIFF
--- a/controllers/aws_config_loader.go
+++ b/controllers/aws_config_loader.go
@@ -28,29 +28,29 @@ import (
 	"github.com/pkg/errors"
 )
 
-// Simple struct to facilitate loading AWS config with region- and endpoint-overrides.
+// AwsConfigLoader is a simple struct to facilitate loading AWS config with region- and endpoint-overrides.
 // This uses venv.Env for mocking in tests.
 type AwsConfigLoader struct {
 	Env venv.Env
 }
 
-// Create an AwsConfigLoader with the default OS environment.
+// NewAwsConfigLoader creates an AwsConfigLoader with the default OS environment.
 func NewAwsConfigLoader() AwsConfigLoader {
 	return NewAwsConfigLoaderForEnv(venv.OS())
 }
 
+// NewAwsConfigLoaderForEnv returns a AwsConfigLoader for the specified environment.
 func NewAwsConfigLoaderForEnv(env venv.Env) AwsConfigLoader {
 	return AwsConfigLoader{
 		Env: env,
 	}
 }
 
-/*
-   As of 11/16/2019 aws-sdk-go-v2 does not supports AWS_WEB_IDENTITY_TOKEN_FILE
-   based credentials. This is a work around to retrieve the credentials from v1
-   and pass to v2.
-   TODO: Remove this function once aws-sdk-go-v2 is fixed.
-*/
+// InstallCredsUsingSDKV1 is required because as of 11/16/2019 aws-sdk-go-v2 does not
+// supports AWS_WEB_IDENTITY_TOKEN_FILE based credentials. This is a work around to
+// retrieve the credentials from v1 and pass to v2.
+// TODO: Remove this function once aws-sdk-go-v2 is fixed.
+// TODO: Change var awsAccessKeyId to awsAccessKeyID
 func (l *AwsConfigLoader) InstallCredsUsingSDKV1(config *aws.Config, regionOverride string) {
 	var err error
 	awsAccessKeyId := l.Env.Getenv("AWS_ACCESS_KEY_ID")
@@ -90,7 +90,7 @@ func (l *AwsConfigLoader) InstallCredsUsingSDKV1(config *aws.Config, regionOverr
 	}
 }
 
-// Load default AWS config and apply overrides, like setting the region and using a custom SageMaker endpoint.
+// LoadAwsConfigWithOverrides loads default AWS config and apply overrides, like setting the region and using a custom SageMaker endpoint.
 // If specified, jobSpecificEndpointOverride always overrides the endpoint. Otherwise, the environment
 // variable specified by DefaultSageMakerEndpointEnvKey overrides the endpoint if it is set.
 func (l AwsConfigLoader) LoadAwsConfigWithOverrides(regionOverride string, jobSpecificEndpointOverride *string) (aws.Config, error) {

--- a/controllers/batchtransformjob/batchtransformjob_controller.go
+++ b/controllers/batchtransformjob/batchtransformjob_controller.go
@@ -39,7 +39,12 @@ import (
 
 // The HTTP message returned with HTTP code 400 if a DescribeTransformJob request
 // cannot find the given transform job.
-const transformResourceNotFoundApiCode string = "ValidationException"
+const (
+	transformResourceNotFoundApiCode string = "ValidationException"
+
+	// Defines the maximum number of characters in a SageMaker Endpoint Config Resource name
+	MaxBatchTransformNameLength = 63
+)
 
 // BatchTransformJobReconciler reconciles a BatchTransformJob object
 type BatchTransformJobReconciler struct {
@@ -262,7 +267,7 @@ func (r *BatchTransformJobReconciler) addFinalizerAndRequeue(ctx reconcileReques
 }
 
 func (r *BatchTransformJobReconciler) getTransformJobName(state batchtransformjobv1.BatchTransformJob) string {
-	return GetGeneratedJobName(state.ObjectMeta.GetUID(), state.ObjectMeta.GetName(), 63)
+	return GetGeneratedJobName(state.ObjectMeta.GetUID(), state.ObjectMeta.GetName(), MaxBatchTransformNameLength)
 }
 
 func (r *BatchTransformJobReconciler) reconcileSpecWithDescription(ctx reconcileRequestContext) (ctrl.Result, error) {

--- a/controllers/batchtransformjob/batchtransformjob_controller.go
+++ b/controllers/batchtransformjob/batchtransformjob_controller.go
@@ -42,7 +42,7 @@ import (
 const (
 	transformResourceNotFoundApiCode string = "ValidationException"
 
-	// Defines the maximum number of characters in a SageMaker Endpoint Config Resource name
+	// Defines the maximum number of characters in a SageMaker Batch Transform Resource name
 	MaxBatchTransformNameLength = 63
 )
 

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -31,32 +31,33 @@ import (
 )
 
 const (
-	// The name of the finalizer that is installed onto managed etcd resources.
+	// SageMakerResourceFinalizerName is the name of the finalizer that is installed onto managed etcd resources.
 	SageMakerResourceFinalizerName = "sagemaker-operator-finalizer"
 
-	// The environment variable key of the default SageMaker endpoint to use.
+	// DefaultSageMakerEndpointEnvKey is the environment variable key of the default SageMaker endpoint to use.
 	// If this is set to anything other than the empty string, the controllers
 	// will use its value as the endpoint with which to communicate with SageMaker.
 	DefaultSageMakerEndpointEnvKey = "AWS_DEFAULT_SAGEMAKER_ENDPOINT"
 
-	// Status stored on first touch of a job by a controller.
+	// InitializingJobStatus is the status stored on first touch of a job by a controller.
 	// This status is kept until the job has a real status.
 	InitializingJobStatus = "SynchronizingK8sJobWithSageMaker"
 )
 
-// The error message to use when a spec differs from its SageMaker description.
+// CreateSpecDiffersFromDescriptionErrorMessage returns the error message to use when a spec differs from its SageMaker description.
 func CreateSpecDiffersFromDescriptionErrorMessage(job interface{}, status, differences string) string {
 	const specDiffersFromDescriptionErrorMessage = "Updates to %s are not supported; the resource no longer matches the SageMaker resource. The job will be marked as \"%s\" and no modifications to the existing SageMaker job will be made until the update is reverted. The differences that prevent tracking of the SageMaker resource are:\n%s"
 	return fmt.Sprintf(specDiffersFromDescriptionErrorMessage, reflect.TypeOf(job).String(), status, differences)
 }
 
-// This string will be added to user agent. This helps to distinguish
+// SagemakerOnKubernetesUserAgentAddition is the string that will be added to user agent. This helps to distinguish
 // sagemaker job which has been created from kubernetes.
 const SagemakerOnKubernetesUserAgentAddition = "sagemaker-on-kubernetes"
 
-// Helper type that describes the action to perform on a resource.
+// ReconcileAction is a helper type that describes the action to perform on a resource.
 type ReconcileAction string
 
+// Constants for the various reconcile actions.
 const (
 	NeedsCreate ReconcileAction = "NeedsCreate"
 	NeedsDelete ReconcileAction = "NeedsDelete"
@@ -64,23 +65,23 @@ const (
 	NeedsUpdate ReconcileAction = "NeedsUpdate"
 )
 
-// Type for function that returns a SageMaker client. Used for mocking.
+// SageMakerClientProvider is a Type for function that returns a SageMaker client. Used for mocking.
 type SageMakerClientProvider func(aws.Config) sagemakeriface.ClientAPI
 
+// RequeueIfError requeues if an error is found.
 func RequeueIfError(err error) (ctrl.Result, error) {
 	return ctrl.Result{}, err
 }
 
-// Helper function which requeues immediately if the object generation has not changed.
+// RequeueImmediatelyUnlessGenerationChanged is a helper function which requeues immediately if the object generation has not changed.
 // Otherwise, since the generation change will trigger an immediate update anyways, this
 // will not requeue.
 // This prevents some cases where two reconciliation loops will occur.
 func RequeueImmediatelyUnlessGenerationChanged(prevGeneration, curGeneration int64) (ctrl.Result, error) {
 	if prevGeneration == curGeneration {
 		return RequeueImmediately()
-	} else {
-		return NoRequeue()
 	}
+	return NoRequeue()
 }
 
 // Note: In unit test we use Result from controller-runtime package from https://github.com/kubernetes-sigs/controller-runtime/blob/2027a413747f2a8cada813dd98b3b1473c253913/pkg/reconcile/reconcile.go#L26
@@ -89,19 +90,22 @@ func RequeueImmediatelyUnlessGenerationChanged(prevGeneration, curGeneration int
 //       if Requeue is False and if duration is 0 then NO requeue, but if duration is > 0 then requeue after duration. Its a bit  confusing hence this note.
 //       Full implementation is available at https://github.com/kubernetes-sigs/controller-runtime/blob/0fdf465bc21be27b20c5b480a1aced84a3347d43/pkg/internal/controller/controller.go#L235-L287
 
+// NoRequeue does not requeue when Requeue is False and duration is 0.
 func NoRequeue() (ctrl.Result, error) {
 	return RequeueIfError(nil)
 }
 
+// RequeueAfterInterval requeues after a duration when duration > 0 is specified.
 func RequeueAfterInterval(interval time.Duration, err error) (ctrl.Result, error) {
 	return ctrl.Result{RequeueAfter: interval}, err
 }
 
+// RequeueImmediately requeues immediately when Requeue is True and no duration is specified.
 func RequeueImmediately() (ctrl.Result, error) {
 	return ctrl.Result{Requeue: true}, nil
 }
 
-// Ignore NotFound errors to prevent reconcile loops.
+// IgnoreNotFound ignores NotFound errors to prevent reconcile loops.
 func IgnoreNotFound(err error) error {
 	if apierrs.IsNotFound(err) {
 		return nil
@@ -109,7 +113,7 @@ func IgnoreNotFound(err error) error {
 	return err
 }
 
-// Helper functions to check and remove string from a slice of strings.
+// ContainsString is a helper functions to check and remove string from a slice of strings.
 func ContainsString(slice []string, s string) bool {
 	for _, item := range slice {
 		if item == s {
@@ -119,6 +123,7 @@ func ContainsString(slice []string, s string) bool {
 	return false
 }
 
+// RemoveString removes a specific string from a splice and returns the rest.
 func RemoveString(slice []string, s string) (result []string) {
 	for _, item := range slice {
 		if item == s {
@@ -129,14 +134,15 @@ func RemoveString(slice []string, s string) (result []string) {
 	return
 }
 
+// GetOrDefault is a helper function to return a default value
 func GetOrDefault(str *string, defaultStr string) string {
 	if str == nil {
 		return defaultStr
-	} else {
-		return *str
 	}
+	return *str
 }
 
+// Now returns timestamp
 func Now() *metav1.Time {
 	now := metav1.Now()
 	return &now
@@ -170,7 +176,7 @@ func GetGeneratedResourceName(required, optional string, maxLen int) string {
 	return required[:maxLen]
 }
 
-// Generates a Sagemaker name for various Kubernetes objects and subresources.
+// GetGeneratedJobName generates a Sagemaker name for various Kubernetes objects and subresources.
 // We need a deterministic way to identify SageMaker resources given a Kubernetes object. This generates
 // a name based off of the UID and object meta name.
 // SageMaker requires that names be less than a certain length. For Training and BatchTransform, the
@@ -184,7 +190,7 @@ func GetGeneratedJobName(objectMetaUID types.UID, objectMetaName string, maxName
 	return GetGeneratedResourceName(strings.Replace(string(objectMetaUID), "-", "", -1), objectMetaName, maxNameLen)
 }
 
-// Helper method that makes logic easier to read.
+// HasDeletionTimestamp is a helper method that makes logic easier to read.
 func HasDeletionTimestamp(obj metav1.ObjectMeta) bool {
 	return !obj.GetDeletionTimestamp().IsZero()
 }

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -142,8 +142,8 @@ func Now() *metav1.Time {
 	return &now
 }
 
-// Generate a SageMaker name for a corresponding Kubernetes object.
-// We need an deterministic way to identiy SageMaker resources given a Kubernetes object. This generates
+// Generates a Sagemaker name for various Kubernetes objects and subresources.
+// We need a deterministic way to identify SageMaker resources given a Kubernetes object. This generates
 // a name based off of the UID and object meta name.
 // SageMaker requires that names be less than a certain length. For Training and BatchTransform, the
 // maximum name length is 63. For HPO, the maximum name length is 32.
@@ -152,32 +152,36 @@ func Now() *metav1.Time {
 // * [CreateTrainingJob#TrainingJobName](https://docs.aws.amazon.com/sagemaker/latest/dg/API_CreateTrainingJob.html#SageMaker-CreateTrainingJob-request-TrainingJobName)
 // * [CreateTransformJob#TransformJobName](https://docs.aws.amazon.com/sagemaker/latest/dg/API_CreateTransformJob.html#SageMaker-CreateTransformJob-request-TransformJobName)
 // * [CreateHyperParameterTuningJob#HyperParameterTuningJobName](https://docs.aws.amazon.com/sagemaker/latest/dg/API_CreateHyperParameterTuningJob.html#SageMaker-CreateHyperParameterTuningJob-request-HyperParameterTuningJobName)
-func GetGeneratedJobName(objectMetaUID types.UID, objectMetaName string, maxNameLen int) string {
-	requiredPostfix := strings.Replace(string(objectMetaUID), "-", "", -1)
-
+func GetGeneratedResourceName(required, optional string, maxLen int) string {
+	// create name: `required + '-' + optional`
 	delimiter := "-"
-	prefix := objectMetaName
-	jobName := prefix + delimiter + requiredPostfix
+	name := optional + delimiter + required
+
+	// truncate if necessary, removing all of optional before any of required
 
 	// If no excess characters, return the job name.
-	if len(jobName) <= maxNameLen {
-		return jobName
+	if len(name) <= maxLen {
+		return name
 	}
 
 	// If can remove excess characters by truncating (and keeping part of) the prefix, do so.
-	excessCharacterCount := len(jobName) - maxNameLen
-	if excessCharacterCount < len(prefix) {
-		return prefix[:len(prefix)-excessCharacterCount] + delimiter + requiredPostfix
+	excessCharacterCount := len(name) - maxLen
+	if excessCharacterCount < len(optional) {
+		return optional[:len(optional)-excessCharacterCount] + delimiter + required
 	}
 
 	// The excess character count is larger than the entire prefix.
-	// We should return the entire requiredPostfix if possible.
-	if len(requiredPostfix) <= maxNameLen {
-		return requiredPostfix
+	// We should return the entire required if possible.
+	if len(required) <= maxLen {
+		return required
 	}
 
 	// If the maxNameLen is smaller than the required postfix, truncate the required postfix.
-	return requiredPostfix[:maxNameLen]
+	return required[:maxLen]
+}
+
+func GetGeneratedJobName(objectMetaUID types.UID, objectMetaName string, maxNameLen int) string {
+	return GetGeneratedResourceName(strings.Replace(string(objectMetaUID), "-", "", -1), objectMetaName, maxNameLen)
 }
 
 // Helper method that makes logic easier to read.

--- a/controllers/common_test.go
+++ b/controllers/common_test.go
@@ -29,32 +29,148 @@ import (
 var _ = Describe("GetGeneratedResourceName", func() {
 
 	var (
+		uid                   types.UID
+		optional              string
+		maxNameLen            int
+		uidWithoutHyphens     string
+		generatedResourceName string
+		required              string
+	)
+
+	BeforeEach(func() {
+		uid = types.UID(uuid.New().String())
+	})
+
+	JustBeforeEach(func() {
+		uidWithoutHyphens = strings.Replace(string(uid), "-", "", -1)
+		required = "generated.postfix" + uidWithoutHyphens
+		generatedResourceName = GetGeneratedResourceName(required, optional, maxNameLen)
+	})
+
+	When("maxNameLen is sufficiently large", func() {
+
+		BeforeEach(func() {
+			maxNameLen = 128
+			optional = "optional.string"
+		})
+
+		It("Concatenates the optional and required strings", func() {
+			Expect(generatedResourceName).To(ContainSubstring(optional))
+			Expect(generatedResourceName).To(ContainSubstring(required))
+		})
+
+		It("Length does not exceed maxNameLen", func() {
+			Expect(len(generatedResourceName)).To(BeNumerically("<=", maxNameLen))
+		})
+	})
+
+	When("maxNameLen is exactly enough", func() {
+
+		BeforeEach(func() {
+			maxNameLen = 128
+			// the 1 accounts for the delimiter
+			requiredLength := len(required) + 1
+			optional = strings.Repeat("A", (maxNameLen - (requiredLength)))
+		})
+
+		It("Concatenates the optional and required strings", func() {
+			Expect(generatedResourceName).To(ContainSubstring(optional))
+			Expect(generatedResourceName).To(ContainSubstring(required))
+		})
+
+		It("Length equals maxNameLen", func() {
+			Expect(len(generatedResourceName)).To(BeNumerically("==", maxNameLen))
+		})
+	})
+
+	When("maxNameLen is not large enough for entire optional string", func() {
+
+		Context("Due to maxNameLen being smaller", func() {
+			BeforeEach(func() {
+				maxNameLen = 64
+				optional = "optional.string"
+			})
+
+			It("Contains the full UID", func() {
+				Expect(generatedResourceName).To(ContainSubstring(uidWithoutHyphens))
+			})
+
+			It("Length does not exceed maxNameLen", func() {
+				Expect(len(generatedResourceName)).To(BeNumerically("<=", maxNameLen))
+			})
+
+			It("Does not start with a hyphen", func() {
+				Expect(generatedResourceName[0]).ToNot(Equal("-"))
+			})
+		})
+
+		Context("Due to objectMetaName being larger", func() {
+			BeforeEach(func() {
+				maxNameLen = 64
+
+				// Kubernetes max is 253.
+				// https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+				optional = strings.Repeat("A", 253)
+			})
+
+			It("Contains the full required string", func() {
+				Expect(generatedResourceName).To(ContainSubstring(required))
+			})
+
+			It("Length does not exceed maxNameLen", func() {
+				Expect(len(generatedResourceName)).To(BeNumerically("<=", maxNameLen))
+			})
+
+			It("Does not start with a hypthen", func() {
+				Expect(generatedResourceName[0]).ToNot(Equal("-"))
+			})
+
+		})
+	})
+
+	When("maxNameLen is not large enough for objectMetaName or full UID", func() {
+
+		BeforeEach(func() {
+			// UID without hyphens is 32.
+			maxNameLen = 30
+			optional = "optional.string"
+		})
+
+		It("Equals the truncated required string", func() {
+			Expect(generatedResourceName).To(Equal(required[:maxNameLen]))
+		})
+
+		It("Length does not exceed maxNameLen", func() {
+			Expect(len(generatedResourceName)).To(BeNumerically("<=", maxNameLen))
+		})
+
+		It("Is contained in the full hyphen-less UID", func() {
+			Expect(required).To(ContainSubstring(generatedResourceName))
+		})
+	})
+})
+
+var _ = Describe("GetGeneratedJobName", func() {
+
+	var (
 		uid            types.UID
 		objectMetaName string
 		maxNameLen     int
 
 		uidWithoutHyphens string
 
-		generatedJobName string
-		generatedPostfix string
-
-		// If this is true, a postfix is added to the job name
-		shouldJobNameHavePostfix bool
+		generatedJobName      string
+		generatedResourceName string
 	)
 
 	BeforeEach(func() {
 		uid = types.UID(uuid.New().String())
-		shouldJobNameHavePostfix = false
 	})
 
 	JustBeforeEach(func() {
 		uidWithoutHyphens = strings.Replace(string(uid), "-", "", -1)
-
-		if shouldJobNameHavePostfix {
-			generatedJobName = GetGeneratedResourceName(generatedPostfix+"-"+uidWithoutHyphens, objectMetaName, maxNameLen)
-		} else {
-			generatedJobName = GetGeneratedJobName(uid, objectMetaName, maxNameLen)
-		}
+		generatedJobName = GetGeneratedJobName(uid, objectMetaName, maxNameLen)
+		generatedResourceName = GetGeneratedJobName(uid, objectMetaName, maxNameLen)
 	})
 
 	When("maxNameLen is sufficiently large", func() {
@@ -72,128 +188,9 @@ var _ = Describe("GetGeneratedResourceName", func() {
 		It("Length does not exceed maxNameLen", func() {
 			Expect(len(generatedJobName)).To(BeNumerically("<=", maxNameLen))
 		})
-	})
 
-	When("maxNameLen is exactly enough", func() {
-
-		BeforeEach(func() {
-			maxNameLen = 64
-			uidWithoutHyphensLength := 32
-			delimiterLength := 1
-			objectMetaName = strings.Repeat("A", (maxNameLen - (uidWithoutHyphensLength + delimiterLength)))
-		})
-
-		It("Concatenates the name and shortened uid", func() {
-			Expect(generatedJobName).To(ContainSubstring(objectMetaName))
-			Expect(generatedJobName).To(ContainSubstring(uidWithoutHyphens))
-		})
-
-		It("Length equals maxNameLen", func() {
-			Expect(len(generatedJobName)).To(BeNumerically("==", maxNameLen))
-		})
-	})
-
-	When("maxNameLen is not large enough for entire objectMetaName", func() {
-
-		Context("Due to maxNameLen being smaller", func() {
-			BeforeEach(func() {
-				maxNameLen = 32
-				objectMetaName = "object.meta.name"
-			})
-
-			It("Contains the full UID", func() {
-				Expect(generatedJobName).To(ContainSubstring(uidWithoutHyphens))
-			})
-
-			It("Length does not exceed maxNameLen", func() {
-				Expect(len(generatedJobName)).To(BeNumerically("<=", maxNameLen))
-			})
-
-			It("Does not start with a hyphen", func() {
-				Expect(generatedJobName[0]).ToNot(Equal("-"))
-			})
-		})
-
-		Context("Due to objectMetaName being larger", func() {
-			BeforeEach(func() {
-				maxNameLen = 64
-
-				// Kubernetes max is 253.
-				// https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-				objectMetaName = strings.Repeat("A", 253)
-			})
-
-			It("Contains the full UID", func() {
-				Expect(generatedJobName).To(ContainSubstring(uidWithoutHyphens))
-			})
-
-			It("Length does not exceed maxNameLen", func() {
-				Expect(len(generatedJobName)).To(BeNumerically("<=", maxNameLen))
-			})
-
-			It("Does not start with a hypthen", func() {
-				Expect(generatedJobName[0]).ToNot(Equal("-"))
-			})
-
-		})
-	})
-
-	When("maxNameLen is not large enough for objectMetaName or full UID", func() {
-
-		BeforeEach(func() {
-			// UID without hyphens is 32.
-			maxNameLen = 30
-			objectMetaName = "object.meta.name"
-		})
-
-		It("Equals the truncated UID", func() {
-			Expect(generatedJobName).To(Equal(uidWithoutHyphens[:maxNameLen]))
-		})
-
-		It("Length does not exceed maxNameLen", func() {
-			Expect(len(generatedJobName)).To(BeNumerically("<=", maxNameLen))
-		})
-
-		It("Is contained in the full hyphen-less UID", func() {
-			Expect(uidWithoutHyphens).To(ContainSubstring(generatedJobName))
-		})
-	})
-
-	When("An additional postfix is required and maxNameLen is sufficiently large", func() {
-		BeforeEach(func() {
-			maxNameLen = 253
-			objectMetaName = "object.meta.name"
-			generatedPostfix = "generated.postfix"
-			shouldJobNameHavePostfix = true
-
-		})
-
-		It("Concatenates the name, shortened uid, generatedPostfix", func() {
-			Expect(generatedJobName).To(ContainSubstring(objectMetaName))
-			Expect(generatedJobName).To(ContainSubstring(uidWithoutHyphens))
-			Expect(generatedJobName).To(ContainSubstring(generatedPostfix))
-		})
-
-		It("Length does not exceed maxNameLen", func() {
-			Expect(len(generatedJobName)).To(BeNumerically("<=", maxNameLen))
-		})
-	})
-
-	When("An additional postfix is required and maxNameLen is not large enough for objectMetaName", func() {
-		BeforeEach(func() {
-			maxNameLen = 64
-			objectMetaName = strings.Repeat("A", 70)
-			generatedPostfix = "generated.postfix"
-			shouldJobNameHavePostfix = true
-		})
-
-		It("Concatenates the shortened uid, generatedPostfix", func() {
-			Expect(generatedJobName).To(ContainSubstring(uidWithoutHyphens))
-			Expect(generatedJobName).To(ContainSubstring(generatedPostfix))
-		})
-
-		It("Length does not exceed maxNameLen", func() {
-			Expect(len(generatedJobName)).To(BeNumerically("<=", maxNameLen))
+		It("returns the same name as GetGeneratedResourceName with uidWithoutHyphens as the required string", func() {
+			Expect(generatedJobName).To(BeEquivalentTo(generatedResourceName))
 		})
 	})
 })

--- a/controllers/common_test.go
+++ b/controllers/common_test.go
@@ -29,21 +29,16 @@ import (
 var _ = Describe("GetGeneratedResourceName", func() {
 
 	var (
-		uid                   types.UID
 		optional              string
 		maxNameLen            int
-		uidWithoutHyphens     string
 		generatedResourceName string
 		required              string
+		requiredPostfix       string
 	)
 
-	BeforeEach(func() {
-		uid = types.UID(uuid.New().String())
-	})
-
 	JustBeforeEach(func() {
-		uidWithoutHyphens = strings.Replace(string(uid), "-", "", -1)
-		required = "generated.postfix" + uidWithoutHyphens
+		requiredPostfix = "bced7caf409947faa7d2161963a1bff7"
+		required = "generated.postfix" + requiredPostfix
 		generatedResourceName = GetGeneratedResourceName(required, optional, maxNameLen)
 	})
 
@@ -92,7 +87,7 @@ var _ = Describe("GetGeneratedResourceName", func() {
 			})
 
 			It("Contains the full UID", func() {
-				Expect(generatedResourceName).To(ContainSubstring(uidWithoutHyphens))
+				Expect(generatedResourceName).To(ContainSubstring(requiredPostfix))
 			})
 
 			It("Length does not exceed maxNameLen", func() {
@@ -144,7 +139,7 @@ var _ = Describe("GetGeneratedResourceName", func() {
 			Expect(len(generatedResourceName)).To(BeNumerically("<=", maxNameLen))
 		})
 
-		It("Is contained in the full hyphen-less UID", func() {
+		It("Is contained in the full required string", func() {
 			Expect(required).To(ContainSubstring(generatedResourceName))
 		})
 	})
@@ -170,7 +165,7 @@ var _ = Describe("GetGeneratedJobName", func() {
 	JustBeforeEach(func() {
 		uidWithoutHyphens = strings.Replace(string(uid), "-", "", -1)
 		generatedJobName = GetGeneratedJobName(uid, objectMetaName, maxNameLen)
-		generatedResourceName = GetGeneratedJobName(uid, objectMetaName, maxNameLen)
+		generatedResourceName = GetGeneratedResourceName(uidWithoutHyphens, objectMetaName, maxNameLen)
 	})
 
 	When("maxNameLen is sufficiently large", func() {

--- a/controllers/endpointconfig/endpointconfig_controller.go
+++ b/controllers/endpointconfig/endpointconfig_controller.go
@@ -339,6 +339,7 @@ func (r *EndpointConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
+// Given a endpointConfig object, generate a Sagemaker name of valid length
 func generateEndpointConfigName(endpointConfig *endpointconfigv1.EndpointConfig) string {
 	return GetGeneratedJobName(endpointConfig.ObjectMeta.GetUID(), endpointConfig.ObjectMeta.GetName(), MaxEndpointConfigNameLength)
 }

--- a/controllers/hosting/endpointconfig_reconciler.go
+++ b/controllers/hosting/endpointconfig_reconciler.go
@@ -20,8 +20,6 @@ import (
 	"context"
 	"fmt"
 	"reflect"
-	"strconv"
-	"strings"
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
@@ -178,7 +176,7 @@ func (r *endpointConfigReconciler) extractDesiredEndpointConfigFromHostingDeploy
 
 	// TODO need to rename production variant names to remove "initial"
 
-	namespacedName := GetKubernetesEndpointConfigNamespacedName(*desiredDeployment)
+	namespacedName := GetSubresourceNamespacedName(desiredDeployment.ObjectMeta.GetName(), *desiredDeployment)
 
 	// Add labels to endpointconfig that indicate which particular HostingDeployment
 	// owns it.
@@ -210,7 +208,7 @@ func (r *endpointConfigReconciler) resolveSageMakerModelName(ctx context.Context
 		return nil, fmt.Errorf("Unable to resolve SageMaker model name for nil deployment")
 	}
 
-	namespacedName := GetKubernetesModelNamespacedName(k8sModelName, *desiredDeployment)
+	namespacedName := GetSubresourceNamespacedName(k8sModelName, *desiredDeployment)
 
 	var model modelv1.Model
 	if err := r.k8sClient.Get(ctx, namespacedName, &model); err != nil {
@@ -226,28 +224,6 @@ func (r *endpointConfigReconciler) resolveSageMakerModelName(ctx context.Context
 	}
 
 	return &model.Status.SageMakerModelName, nil
-}
-
-// Get the idempotent name of the EndpointConfig in Kubernetes.
-// Kubernetes resources can have names up to 253 characters long.
-// The characters allowed in names are: digits (0-9), lower case letters (a-z), -, and .
-func GetKubernetesEndpointConfigNamespacedName(deployment hostingv1.HostingDeployment) types.NamespacedName {
-	k8sMaxLen := 253
-	name := deployment.ObjectMeta.GetName()
-	uid := strings.Replace(string(deployment.ObjectMeta.GetUID()), "-", "", -1)
-	generation := strconv.FormatInt(deployment.ObjectMeta.GetGeneration(), 10)
-
-	requiredPostfix := "-" + generation + "-" + uid
-	endpointConfigName := name + requiredPostfix
-
-	if len(endpointConfigName) > k8sMaxLen {
-		endpointConfigName = name[:k8sMaxLen-len(requiredPostfix)] + requiredPostfix
-	}
-
-	return types.NamespacedName{
-		Name:      endpointConfigName,
-		Namespace: deployment.ObjectMeta.GetNamespace(),
-	}
 }
 
 // Get the existing Kubernetes EndpointConfig. If it does not exist, return nil.

--- a/controllers/hosting/endpointconfig_reconciler_test.go
+++ b/controllers/hosting/endpointconfig_reconciler_test.go
@@ -98,7 +98,7 @@ var _ = Describe("EndpointConfigReconciler.Reconcile", func() {
 
 	It("Will not create if an EndpointConfig exists already and they are deep equal", func() {
 		desired = createHostingDeploymentWithBasicProductionVariant()
-		key := GetKubernetesEndpointConfigNamespacedName(desired)
+		key := GetSubresourceNamespacedName(desired.ObjectMeta.GetName(), desired)
 
 		err := k8sClient.Create(context.Background(), &endpointconfigv1.EndpointConfig{
 			ObjectMeta: metav1.ObjectMeta{
@@ -122,7 +122,7 @@ var _ = Describe("EndpointConfigReconciler.Reconcile", func() {
 		updateEndpointConfigStatus(key, endpointconfigcontroller.CreatedStatus, "sagemaker-endpoint-name")
 
 		modelName := *desired.Spec.ProductionVariants[0].ModelName
-		modelNamespacedName := GetKubernetesModelNamespacedName(modelName, desired)
+		modelNamespacedName := GetSubresourceNamespacedName(modelName, desired)
 		Expect(createCreatedModelWithAnySageMakerName(modelNamespacedName, desired)).ToNot(HaveOccurred())
 
 		// Fail test if Create is called on k8s client.
@@ -146,7 +146,7 @@ var _ = Describe("EndpointConfigReconciler.Reconcile", func() {
 
 			// Create model correct status
 			modelName := *desired.Spec.ProductionVariants[0].ModelName
-			modelNamespacedName := GetKubernetesModelNamespacedName(modelName, desired)
+			modelNamespacedName := GetSubresourceNamespacedName(modelName, desired)
 
 			Expect(createCreatedModelWithAnySageMakerName(modelNamespacedName, desired)).ToNot(HaveOccurred())
 		})
@@ -179,12 +179,12 @@ var _ = Describe("EndpointConfigReconciler.Reconcile", func() {
 				},
 			}
 
-			expectedEndpointConfigNamespacedName = GetKubernetesEndpointConfigNamespacedName(desired)
+			expectedEndpointConfigNamespacedName = GetSubresourceNamespacedName(desired.ObjectMeta.GetName(), desired)
 
 			// Create models
 
 			modelName := *desired.Spec.ProductionVariants[0].ModelName
-			modelNamespacedName := GetKubernetesModelNamespacedName(modelName, desired)
+			modelNamespacedName := GetSubresourceNamespacedName(modelName, desired)
 			Expect(createCreatedModelWithAnySageMakerName(modelNamespacedName, desired)).ToNot(HaveOccurred())
 
 			reconciler.Reconcile(context.Background(), &desired, true)
@@ -256,12 +256,12 @@ var _ = Describe("Delete EndpointConfigReconciler.Reconcile", func() {
 			},
 		}
 
-		expectedEndpointConfigNamespacedName = GetKubernetesEndpointConfigNamespacedName(desired)
+		expectedEndpointConfigNamespacedName = GetSubresourceNamespacedName(desired.ObjectMeta.GetName(), desired)
 
 		// Create models
 
 		modelName := *desired.Spec.ProductionVariants[0].ModelName
-		modelNamespacedName := GetKubernetesModelNamespacedName(modelName, desired)
+		modelNamespacedName := GetSubresourceNamespacedName(modelName, desired)
 		Expect(createCreatedModelWithAnySageMakerName(modelNamespacedName, desired)).ToNot(HaveOccurred())
 
 		reconciler.Reconcile(context.Background(), &desired, true)
@@ -332,11 +332,11 @@ var _ = Describe("Update EndpointConfigReconciler.Reconcile", func() {
 			},
 		}
 
-		endpointConfigNamespacedName = GetKubernetesEndpointConfigNamespacedName(*desired)
+		endpointConfigNamespacedName = GetSubresourceNamespacedName(desired.ObjectMeta.GetName(), *desired)
 		err := createCreatedEndpointConfig(endpointConfigNamespacedName, *desired, "")
 		Expect(err).ToNot(HaveOccurred())
 
-		err = createCreatedModelWithAnySageMakerName(GetKubernetesModelNamespacedName(modelName, *desired), *desired)
+		err = createCreatedModelWithAnySageMakerName(GetSubresourceNamespacedName(modelName, *desired), *desired)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -351,7 +351,7 @@ var _ = Describe("Update EndpointConfigReconciler.Reconcile", func() {
 		err = k8sClient.Delete(context.Background(), &endpointConfig)
 		Expect(err).ToNot(HaveOccurred())
 
-		modelNamespacedName := GetKubernetesModelNamespacedName(modelName, *desired)
+		modelNamespacedName := GetSubresourceNamespacedName(modelName, *desired)
 		var model modelv1.Model
 		err = k8sClient.Get(context.Background(), types.NamespacedName{
 			Namespace: modelNamespacedName.Namespace,

--- a/controllers/hosting/hostingdeployment_controller_test.go
+++ b/controllers/hosting/hostingdeployment_controller_test.go
@@ -268,7 +268,7 @@ var _ = Describe("Reconciling a HostingDeployment that exists", func() {
 
 				createdRequest := req.(*sagemaker.CreateEndpointInput)
 				Expect(*createdRequest.EndpointConfigName).To(Equal(endpointConfigSageMakerName))
-				Expect(*createdRequest.EndpointName).To(Equal(GetSageMakerEndpointName(*deployment)))
+				Expect(*createdRequest.EndpointName).To(Equal(controllercommon.GetGeneratedJobName(deployment.ObjectMeta.GetUID(), deployment.ObjectMeta.GetName(), 63)))
 			})
 
 			It("Requeues after interval", func() {
@@ -1004,7 +1004,7 @@ func AddFinalizer(deployment *hostingv1.HostingDeployment) {
 
 // Create an EndpointConfig with a SageMaker name in the status.
 func CreateEndpointConfigWithSageMakerName(deployment *hostingv1.HostingDeployment, endpointConfigSageMakerName string) {
-	namespacedName := GetKubernetesEndpointConfigNamespacedName(*deployment)
+	namespacedName := GetSubresourceNamespacedName(deployment.ObjectMeta.GetName(), *deployment)
 
 	endpointConfig := endpointconfigv1.EndpointConfig{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1056,7 +1056,7 @@ func ExpectRequestToDeleteHostingDeployment(req interface{}, deployment *hosting
 	Expect(req).To(BeAssignableToTypeOf((*sagemaker.DeleteEndpointInput)(nil)))
 
 	deleteRequest := req.(*sagemaker.DeleteEndpointInput)
-	Expect(*deleteRequest.EndpointName).To(Equal(GetSageMakerEndpointName(*deployment)))
+	Expect(*deleteRequest.EndpointName).To(Equal(controllercommon.GetGeneratedJobName(deployment.ObjectMeta.GetUID(), deployment.ObjectMeta.GetName(), 63)))
 }
 
 // Helper function to verify that the specified object is n UpdateEndpointInput and that it requests to update the HostingDeployment correctly.
@@ -1064,7 +1064,7 @@ func ExpectRequestToUpdateHostingDeployment(req interface{}, deployment *hosting
 	Expect(req).To(BeAssignableToTypeOf((*sagemaker.UpdateEndpointInput)(nil)))
 
 	updateRequest := req.(*sagemaker.UpdateEndpointInput)
-	Expect(*updateRequest.EndpointName).To(Equal(GetSageMakerEndpointName(*deployment)))
+	Expect(*updateRequest.EndpointName).To(Equal(controllercommon.GetGeneratedJobName(deployment.ObjectMeta.GetUID(), deployment.ObjectMeta.GetName(), 63)))
 	Expect(*updateRequest.EndpointConfigName).To(Equal(expectedEndpointConfigName))
 }
 

--- a/controllers/hosting/model_reconciler_test.go
+++ b/controllers/hosting/model_reconciler_test.go
@@ -313,7 +313,7 @@ var _ = Describe("ModelReconciler.Reconcile", func() {
 				},
 			}
 
-			expectedModelName = GetKubernetesModelNamespacedName("model-name", *desired).Name
+			expectedModelName = GetSubresourceNamespacedName("model-name", *desired).Name
 
 			reconciler.Reconcile(context.Background(), desired, true)
 		})
@@ -446,7 +446,7 @@ var _ = Describe("Delete ModelReconciler.Reconcile", func() {
 			},
 		}
 
-		expectedModelName = GetKubernetesModelNamespacedName("model-name", *desired).Name
+		expectedModelName = GetSubresourceNamespacedName("model-name", *desired).Name
 
 		var model modelv1.Model
 
@@ -528,7 +528,7 @@ var _ = Describe("ModelReconciler.GetSageMakerModelNames", func() {
 			},
 		}
 
-		modelNamespacedName = GetKubernetesModelNamespacedName(modelName, *desired)
+		modelNamespacedName = GetSubresourceNamespacedName(modelName, *desired)
 	})
 
 	AfterEach(func() {
@@ -616,7 +616,7 @@ var _ = Describe("Update ModelReconciler.Reconcile", func() {
 			},
 		}
 
-		modelNamespacedName = GetKubernetesModelNamespacedName(modelName, *desired)
+		modelNamespacedName = GetSubresourceNamespacedName(modelName, *desired)
 		err := createCreatedModelWithSageMakerName(modelNamespacedName, *desired, "")
 		Expect(err).ToNot(HaveOccurred())
 	})

--- a/controllers/model/model_controller.go
+++ b/controllers/model/model_controller.go
@@ -335,7 +335,7 @@ func (r *ModelReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-// Given a Model object, generate a Sagemaker name of valid length
+// Given a Model object, generate a SageMaker name of valid length
 func generateModelName(model *modelv1.Model) string {
 	return GetGeneratedJobName(model.ObjectMeta.GetUID(), model.ObjectMeta.GetName(), MaxModelNameLength)
 }

--- a/controllers/model/model_controller.go
+++ b/controllers/model/model_controller.go
@@ -19,7 +19,6 @@ package model
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -47,6 +46,9 @@ const (
 
 	// Status to indicate that an error occurred during reconciliation.
 	ErrorStatus = "Error"
+
+	// Defines the maximum number of characters in a SageMaker Model SubResource name
+	MaxModelNameLength = 63
 )
 
 // ModelReconciler reconciles a Model object
@@ -324,18 +326,6 @@ func (r *ModelReconciler) updateStatusWithAdditional(ctx reconcileRequestContext
 	return nil
 }
 
-func generateModelName(model *modelv1.Model) string {
-	sageMakerMaxNameLen := 63
-	name := model.ObjectMeta.GetName()
-	requiredPostfix := "-" + strings.Replace(string(model.ObjectMeta.GetUID()), "-", "", -1)
-
-	sageMakerModelName := name + requiredPostfix
-	if len(sageMakerModelName) > sageMakerMaxNameLen {
-		sageMakerModelName = name[:sageMakerMaxNameLen-len(requiredPostfix)] + requiredPostfix
-	}
-	return sageMakerModelName
-}
-
 // TODO add code that ignores status, metadata updates.
 func (r *ModelReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
@@ -343,4 +333,8 @@ func (r *ModelReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		// Ignore status-only and metadata-only updates
 		WithEventFilter(predicate.GenerationChangedPredicate{}).
 		Complete(r)
+}
+
+func generateModelName(model *modelv1.Model) string {
+	return GetGeneratedJobName(model.ObjectMeta.GetUID(), model.ObjectMeta.GetName(), MaxModelNameLength)
 }

--- a/controllers/model/model_controller.go
+++ b/controllers/model/model_controller.go
@@ -335,6 +335,7 @@ func (r *ModelReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
+// Given a Model object, generate a Sagemaker name of valid length
 func generateModelName(model *modelv1.Model) string {
 	return GetGeneratedJobName(model.ObjectMeta.GetUID(), model.ObjectMeta.GetName(), MaxModelNameLength)
 }


### PR DESCRIPTION
Deduplicate logic that calculates generated names, truncating them for certain lengths. 

Testing:
All Unit tests have passed. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

