### PR TITLE
Fix runtime failures not propagating to "Additional" in status

### DIFF
--- a/controllers/hyperparametertuningjob/hyperparametertuningjob_controller.go
+++ b/controllers/hyperparametertuningjob/hyperparametertuningjob_controller.go
@@ -211,8 +211,14 @@ func (r *Reconciler) reconcileTuningJob(ctx reconcileRequestContext) error {
 		return r.updateStatusAndReturnError(ctx, ReconcilingTuningJobStatus, fmt.Errorf("Unknown Tuning Job Status: %s", ctx.TuningJobDescription.HyperParameterTuningJobStatus))
 	}
 
-	if err = r.updateStatus(ctx, string(ctx.TuningJobDescription.HyperParameterTuningJobStatus)); err != nil {
-		return err
+	if ctx.TuningJobDescription.FailureReason != nil {
+		if err = r.updateStatusWithAdditional(ctx, string(ctx.TuningJobDescription.HyperParameterTuningJobStatus), *ctx.TuningJobDescription.FailureReason); err != nil {
+			return err
+		}
+	} else {
+		if err = r.updateStatus(ctx, string(ctx.TuningJobDescription.HyperParameterTuningJobStatus)); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/controllers/hyperparametertuningjob/hyperparametertuningjob_controller.go
+++ b/controllers/hyperparametertuningjob/hyperparametertuningjob_controller.go
@@ -211,14 +211,11 @@ func (r *Reconciler) reconcileTuningJob(ctx reconcileRequestContext) error {
 		return r.updateStatusAndReturnError(ctx, ReconcilingTuningJobStatus, fmt.Errorf("Unknown Tuning Job Status: %s", ctx.TuningJobDescription.HyperParameterTuningJobStatus))
 	}
 
-	if ctx.TuningJobDescription.FailureReason != nil {
-		if err = r.updateStatusWithAdditional(ctx, string(ctx.TuningJobDescription.HyperParameterTuningJobStatus), *ctx.TuningJobDescription.FailureReason); err != nil {
-			return err
-		}
-	} else {
-		if err = r.updateStatus(ctx, string(ctx.TuningJobDescription.HyperParameterTuningJobStatus)); err != nil {
-			return err
-		}
+	status := string(ctx.TuningJobDescription.HyperParameterTuningJobStatus)
+	additional := controllers.GetOrDefault(ctx.TuningJobDescription.FailureReason, "")
+
+	if err = r.updateStatusWithAdditional(ctx, status, additional); err != nil {
+		return err
 	}
 
 	return nil

--- a/controllers/trainingjob/trainingjob_controller.go
+++ b/controllers/trainingjob/trainingjob_controller.go
@@ -210,6 +210,10 @@ func (r *Reconciler) reconcileTrainingJob(ctx reconcileRequestContext) error {
 		if err = r.updateStatus(ctx, string(ctx.TrainingJobDescription.TrainingJobStatus), ""); err != nil {
 			return err
 		}
+	} else if ctx.TrainingJobDescription.FailureReason != nil {
+		if err = r.updateStatusWithAdditional(ctx, string(ctx.TrainingJobDescription.TrainingJobStatus), string(ctx.TrainingJobDescription.SecondaryStatus), *ctx.TrainingJobDescription.FailureReason); err != nil {
+			return err
+		}
 	} else {
 		if err = r.updateStatus(ctx, string(ctx.TrainingJobDescription.TrainingJobStatus), string(ctx.TrainingJobDescription.SecondaryStatus)); err != nil {
 			return err

--- a/controllers/trainingjob/trainingjob_controller.go
+++ b/controllers/trainingjob/trainingjob_controller.go
@@ -204,20 +204,18 @@ func (r *Reconciler) reconcileTrainingJob(ctx reconcileRequestContext) error {
 		return r.updateStatusAndReturnError(ctx, ReconcilingTrainingJobStatus, "", unknownStateError)
 	}
 
+	primaryStatus := string(ctx.TrainingJobDescription.TrainingJobStatus)
+	secondaryStatus := string(ctx.TrainingJobDescription.SecondaryStatus)
+	additional := controllers.GetOrDefault(ctx.TrainingJobDescription.FailureReason, "")
+
 	if ctx.TrainingJobDescription.TrainingJobStatus == sagemaker.TrainingJobStatusStopping {
 		// Clear the secondary status if we detected stopping, since SageMaker has unclear secondary statuses during this phase
 		// Open ticket with the SageMaker team: https://t.corp.amazon.com/0411302791
-		if err = r.updateStatus(ctx, string(ctx.TrainingJobDescription.TrainingJobStatus), ""); err != nil {
-			return err
-		}
-	} else if ctx.TrainingJobDescription.FailureReason != nil {
-		if err = r.updateStatusWithAdditional(ctx, string(ctx.TrainingJobDescription.TrainingJobStatus), string(ctx.TrainingJobDescription.SecondaryStatus), *ctx.TrainingJobDescription.FailureReason); err != nil {
-			return err
-		}
-	} else {
-		if err = r.updateStatus(ctx, string(ctx.TrainingJobDescription.TrainingJobStatus), string(ctx.TrainingJobDescription.SecondaryStatus)); err != nil {
-			return err
-		}
+		secondaryStatus = ""
+	}
+
+	if err = r.updateStatusWithAdditional(ctx, primaryStatus, secondaryStatus, additional); err != nil {
+		return err
 	}
 
 	return nil

--- a/tests/codebuild/common.sh
+++ b/tests/codebuild/common.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# Create a resource (run a test) given a specification yaml.
+# Parameter: $1 filename of test
+function run_test()
+{
+  kubectl apply -f "$1"
+}
+
 # This function gets the sagemaker model name from k8s model
 # Parameter:
 #    $1: Name of k8s model

--- a/tests/codebuild/create_tests.sh
+++ b/tests/codebuild/create_tests.sh
@@ -65,13 +65,6 @@ function verify_integration_tests
   verify_test HyperparameterTuningJob xgboost-mnist-hpo-custom-endpoint 20m Completed
 }
 
-# Create a resource (run a test) given a specification yaml.
-# Parameter: $1 filename of test
-function run_test()
-{
-  kubectl apply -f "$1"
-}
-
 # This function verifies that job has started and not failed
 # Parameter:
 #    $1: Kind of CRD

--- a/tests/codebuild/feature_tests.sh
+++ b/tests/codebuild/feature_tests.sh
@@ -54,7 +54,7 @@ function verify_feature_integration_tests
     echo "[FAILED] Not all failed training jobs in failing HPO job contained the additional in their statuses"
     exit 1
   fi
-  echo "[SUCCESS] HyperParameterTuningJob with Failed status has it's additional status set and set for all TrainingJobs"
+  echo "[SUCCESS] HyperParameterTuningJob with Failed status has its additional status set and set for all TrainingJobs"
 }
 
 # This function verifies that a given training job has a failure reason in the 

--- a/tests/codebuild/feature_tests.sh
+++ b/tests/codebuild/feature_tests.sh
@@ -48,12 +48,13 @@ function verify_feature_integration_tests
   fi
   if ! verify_resource_has_additional HyperParameterTuningJob failing-xgboost-mnist-hpo; then
     echo "[FAILED] Failing hyperparameter tuning job does not have any additional status set"
+    exit 1
   fi
   if ! verify_failed_trainingjobs_from_hpo_have_additional failing-xgboost-mnist-hpo; then
     echo "[FAILED] Not all failed training jobs in failing HPO job contained the additional in their statuses"
     exit 1
   fi
-  echo "[SUCCESS] HyperParameterTuningJob with Failed status has additional set for all TrainingJobs"
+  echo "[SUCCESS] HyperParameterTuningJob with Failed status has it's additional status set and set for all TrainingJobs"
 }
 
 # This function verifies that a given training job has a failure reason in the 
@@ -80,11 +81,11 @@ function verify_failed_trainingjobs_from_hpo_have_additional
 {
   local crd_instance="$1"
 
-  local sagemakerHPOJobName="$(kubectl get hyperparametertuningjob "$crd_instance" -o json | jq -r '.status.sageMakerHyperParameterTuningJobName')"
+  local sagemaker_hpo_job_name="$(kubectl get hyperparametertuningjob "$crd_instance" -o json | jq -r '.status.sageMakerHyperParameterTuningJobName')"
 
   # Loop over every failed training job and get the k8s resource name
-  for trainingJob in $(kubectl get trainingjob | grep Failed | grep "$sagemakerHPOJobName" | awk '{print $1}'); do
-    if ! verify_resource_has_additional TrainingJob "$trainingJob"; then
+  for training_job in $(kubectl get trainingjob | grep Failed | grep "$sagemaker_hpo_job_name" | awk '{print $1}'); do
+    if ! verify_resource_has_additional TrainingJob "$training_job"; then
       return 1
     fi
   done

--- a/tests/codebuild/feature_tests.sh
+++ b/tests/codebuild/feature_tests.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+source common.sh
+source inject_tests.sh
+
+# Applies each of the resources needed for the canary tests.
+function run_feature_canary_tests
+{
+  echo "Running feature canary tests"
+  inject_all_variables
+}
+
+# Applies each of the resources needed for the integration tests.
+function run_feature_integration_tests
+{
+  echo "Running feature integration tests"
+  run_feature_canary_tests
+
+  run_test testfiles/failing-xgboost-mnist-hpo.yaml
+  run_test testfiles/failing-xgboost-mnist-trainingjob.yaml
+}
+
+function verify_feature_canary_tests
+{
+  echo "Verifying feature canary tests"
+}
+
+function verify_feature_integration_tests
+{
+  echo "Verifying feature integration tests"
+  verify_feature_canary_tests
+
+  wait_for_crd_status TrainingJob failing-xgboost-mnist 5m Failed
+  verify_trainingjob_has_additional failing-xgboost-mnist
+  echo "[SUCCESS] TrainingJob with Failed status has additional set."
+
+  wait_for_crd_status HyperParameterTuningJob failing-xgboost-mnist-hpo 10m Failed
+  verify_failed_trainingjobs_from_hpo_have_additional failing-xgboost-mnist-hpo
+  echo "[SUCCESS] HyperParameterTuningJob with Failed status has additional set for all TrainingJobs."
+}
+
+# This function verifies that a given training job has a failure reason in the 
+# additional part of the status.
+# Parameter:
+#    $1: Instance of TraininGJob
+function verify_trainingjob_has_additional
+{
+  local crd_instance="$1"
+  local additional="$(kubectl get trainingjob "$crd_instance" -o json | jq -r '.status.additional')"
+
+  if [ -z "$additional" ]; then
+    echo "[FAILED] ${crd_instance} does not have any additional status set." 
+    exit 1
+  fi
+}
+
+# This function verifies that each Failed trainingjob for a given HPO job have
+# the additional field in their status set.
+# Parameter:
+#    $1: Instance of HyperParameterTuningJob
+function verify_failed_trainingjobs_from_hpo_have_additional
+{
+  local crd_instance="$1"
+
+  local sagemakerHPOJobName="$(kubectl get hyperparametertuningjob "$crd_instance" -o json | jq -r '.status.sageMakerHyperParameterTuningJobName')"
+
+  # Loop over every failed training job and get the k8s resource name
+  for trainingJob in $(kubectl get trainingjob | grep Failed | grep "$sagemakerHPOJobName" | awk '{print $1}'); do
+    verify_trainingjob_has_additional "$trainingJob"
+  done
+}

--- a/tests/codebuild/inject_tests.sh
+++ b/tests/codebuild/inject_tests.sh
@@ -29,4 +29,6 @@ function inject_all_variables
   inject_variables testfiles/xgboost-model.yaml
   inject_variables testfiles/xgboost-mnist-batchtransform.yaml
   inject_variables testfiles/xgboost-hosting-deployment.yaml
+  inject_variables testfiles/failing-xgboost-mnist-trainingjob.yaml
+  inject_variables testfiles/failing-xgboost-mnist-hpo.yaml
 }

--- a/tests/codebuild/local-run/.env.example
+++ b/tests/codebuild/local-run/.env.example
@@ -7,6 +7,9 @@ ALPHA_TARBALL_BUCKET=
 # The particular commit SHA to test against
 CODEBUILD_RESOLVED_SOURCE_VERSION=
 
+# (Optional) Skip installation of the CRDs and controller into the cluster
+# SKIP_INSTALLATION=true
+
 # The credentials to pass the operator installation scripts
 OPERATOR_AWS_ACCESS_KEY_ID=
 OPERATOR_AWS_SECRET_ACCESS_KEY=
@@ -16,3 +19,6 @@ ROLE_ARN=arn:aws:iam::
 
 # (Optional) An existing FSX cluster with training data
 # FSX_ID=fs-0c80e27f4c1c49d96
+
+# (Optional) Print all controller logs in the event of a failure
+# PRINT_DEBUG=false

--- a/tests/codebuild/local-run/README.md
+++ b/tests/codebuild/local-run/README.md
@@ -2,7 +2,18 @@
 The files in this directory allow a developer to run integration tests locally, in almost exactly the same environment as they would run in Codebuild, against their own cluster. This speeds up the development process of integration tests as you don't have to wait for an EKS cluster to spin up or spin down. This can also be used to run integration tests against a change (for example, before a developer pushes a CR), albiet with some caveats.
 
 ## How to run against an existing cluster
-Run:
+
+### 1. Configure your environment variables
+Environment variables are the way we configure the options and debugging modes for our integration tests.
+We provide an example `.env` file (`.env.example`) which contains a list of each option and how to configure
+your integration tests.
+
+```bash
+cp .env.example .env
+vim .env
+```
+
+### 2. Run integration test script
 
 ```bash
 KUBECONFIG=/path/to/kubeconfig ./run_integration_test_against_existing_cluster.sh
@@ -12,5 +23,4 @@ This will build a Docker image that is based on the integration test Docker imag
 
 ## Notes / Caveats:
 * The integration test files are copied into the Docker container at runtime (akin to cloning a repo), so you do not need to push them anywhere beforehand.
-* Our tests are currently set up to pull an installation package from s3. If you want to test some new code that you have written, you must currently hack that code to pull your own s3 installation package (which itself points to a published controller image). This should be improved in the future when someone wants to use this.
-* You should provide a `.env` file in the `tests/codebuild/local-run` directory containing all the relevant environment variables. An example `.env.example` file has been provided with all the required variables to run existing tests.
+* Our tests are currently set up to pull an installation package from S3. This package contains the CRDs and controller image, as well as any binaries we hope to test. If you would like to install your CRDs prior, and run the controller locally, use the `SKIP_INSTALLATION=true` option in your `.env`.

--- a/tests/codebuild/run_all_sample_canary_tests.sh
+++ b/tests/codebuild/run_all_sample_canary_tests.sh
@@ -1,12 +1,15 @@
 #!/bin/bash
 
 source create_tests.sh
+source feature_tests.sh
 source delete_tests.sh
 source inject_tests.sh
 source smlogs_tests.sh
 
 run_canary_tests
 verify_canary_tests
+run_feature_canary_tests
+verify_feature_canary_tests
 run_smlogs_canary_tests
 delete_all_resources # Delete all existing resources to re-use metadata names
 run_delete_canary_tests

--- a/tests/codebuild/run_all_sample_canary_tests.sh
+++ b/tests/codebuild/run_all_sample_canary_tests.sh
@@ -7,8 +7,8 @@ source inject_tests.sh
 source smlogs_tests.sh
 
 run_canary_tests
-verify_canary_tests
 run_feature_canary_tests
+verify_canary_tests
 verify_feature_canary_tests
 run_smlogs_canary_tests
 delete_all_resources # Delete all existing resources to re-use metadata names

--- a/tests/codebuild/run_all_sample_test.sh
+++ b/tests/codebuild/run_all_sample_test.sh
@@ -7,8 +7,8 @@ source inject_tests.sh
 source smlogs_tests.sh
 
 run_integration_tests
-verify_integration_tests
 run_feature_integration_tests
+verify_integration_tests
 verify_feature_integration_tests
 run_smlogs_integration_tests
 delete_all_resources # Delete all existing resources to re-use metadata names

--- a/tests/codebuild/run_all_sample_test.sh
+++ b/tests/codebuild/run_all_sample_test.sh
@@ -1,12 +1,15 @@
 #!/bin/bash
 
 source create_tests.sh
+source feature_tests.sh
 source delete_tests.sh
 source inject_tests.sh
 source smlogs_tests.sh
 
 run_integration_tests
 verify_integration_tests
+run_feature_integration_tests
+verify_feature_integration_tests
 run_smlogs_integration_tests
 delete_all_resources # Delete all existing resources to re-use metadata names
 run_delete_integration_tests

--- a/tests/codebuild/testfiles/failing-xgboost-mnist-hpo.yaml
+++ b/tests/codebuild/testfiles/failing-xgboost-mnist-hpo.yaml
@@ -1,0 +1,112 @@
+apiVersion: sagemaker.aws.amazon.com/v1
+kind: HyperparameterTuningJob
+metadata:
+  name: failing-xgboost-mnist-hpo
+spec:
+    region: us-west-2
+    tags:
+      - key: test-key
+        value: test-value
+    hyperParameterTuningJobConfig:
+      strategy: Bayesian
+      hyperParameterTuningJobObjective:
+        type: Minimize
+        metricName: validation:error
+      resourceLimits:
+        maxNumberOfTrainingJobs: 10
+        maxParallelTrainingJobs: 5
+      parameterRanges:
+        integerParameterRanges:
+        - name: num_round
+          minValue: '10'
+          maxValue: '20'
+          scalingType: Linear
+        continuousParameterRanges: []
+        categoricalParameterRanges: []
+      trainingJobEarlyStoppingType: Auto
+    trainingJobDefinition:
+      staticHyperParameters:
+        - name: base_score
+          value: '0.5'
+        - name: booster
+          value: gbtree
+        - name: csv_weights
+          value: '0'
+        - name: dsplit
+          value: row
+        - name: grow_policy
+          value: depthwise
+        - name: lambda_bias
+          value: '0.0'
+        - name: max_bin
+          value: '256'
+        - name: max_leaves
+          value: '0'
+        - name: normalize_type
+          value: tree
+        - name: objective
+          value: reg:linear
+        - name: one_drop
+          value: '0'
+        - name: prob_buffer_row
+          value: '1.0'
+        - name: process_type
+          value: default
+        - name: rate_drop
+          value: '0.0'
+        - name: refresh_leaf
+          value: '1'
+        - name: sample_type
+          value: uniform
+        - name: scale_pos_weight
+          value: '1.0'
+        - name: silent
+          value: '0'
+        - name: sketch_eps
+          value: '0.03'
+        - name: skip_drop
+          value: '0.0'
+        - name: tree_method
+          value: auto
+        - name: tweedie_variance_power
+          value: '1.5'
+        - name: updater
+          value: grow_colmaker,prune
+      algorithmSpecification:
+        trainingImage: 763104351884.dkr.ecr.us-west-2.amazonaws.com/tensorflow-training:2.0.1-gpu-py36-cu100-ubuntu18.04
+        trainingInputMode: File
+        metricDefinitions:
+        - name: validation:error
+          regex: "validation_error=(.*?);"
+      roleArn: {ROLE_ARN}
+      inputDataConfig:
+      - channelName: train
+        dataSource:
+          s3DataSource:
+            s3DataType: S3Prefix
+            s3Uri: s3://{DATA_BUCKET}/train/
+            s3DataDistributionType: FullyReplicated
+        contentType: text/csv
+        compressionType: None
+        recordWrapperType: None
+        inputMode: File
+      - channelName: validation
+        dataSource:
+          s3DataSource:
+            s3DataType: S3Prefix
+            s3Uri: s3://{DATA_BUCKET}/validation/
+            s3DataDistributionType: FullyReplicated
+        contentType: text/csv
+        compressionType: None
+        recordWrapperType: None
+        inputMode: File
+      outputDataConfig:
+        s3OutputPath: s3://{DATA_BUCKET}/xgboost
+      resourceConfig:
+        instanceType: ml.m4.xlarge
+        instanceCount: 1
+        volumeSizeInGB: 25
+      stoppingCondition:
+        maxRuntimeInSeconds: 3600
+      enableNetworkIsolation: true
+      enableInterContainerTrafficEncryption: false

--- a/tests/codebuild/testfiles/failing-xgboost-mnist-hpo.yaml
+++ b/tests/codebuild/testfiles/failing-xgboost-mnist-hpo.yaml
@@ -1,3 +1,7 @@
+# This HPO job was designed to fail during the "Training" phase.
+# The image specified refers to a plain Tensorflow DLC image that does not have
+# the correct entrypoint for a SageMaker training job. This will fail with a 
+# python exception that should be captured by the operator.
 apiVersion: sagemaker.aws.amazon.com/v1
 kind: HyperparameterTuningJob
 metadata:

--- a/tests/codebuild/testfiles/failing-xgboost-mnist-hpo.yaml
+++ b/tests/codebuild/testfiles/failing-xgboost-mnist-hpo.yaml
@@ -3,110 +3,110 @@ kind: HyperparameterTuningJob
 metadata:
   name: failing-xgboost-mnist-hpo
 spec:
-    region: us-west-2
-    tags:
-      - key: test-key
-        value: test-value
-    hyperParameterTuningJobConfig:
-      strategy: Bayesian
-      hyperParameterTuningJobObjective:
-        type: Minimize
-        metricName: validation:error
-      resourceLimits:
-        maxNumberOfTrainingJobs: 10
-        maxParallelTrainingJobs: 5
-      parameterRanges:
-        integerParameterRanges:
-        - name: num_round
-          minValue: '10'
-          maxValue: '20'
-          scalingType: Linear
-        continuousParameterRanges: []
-        categoricalParameterRanges: []
-      trainingJobEarlyStoppingType: Auto
-    trainingJobDefinition:
-      staticHyperParameters:
-        - name: base_score
-          value: '0.5'
-        - name: booster
-          value: gbtree
-        - name: csv_weights
-          value: '0'
-        - name: dsplit
-          value: row
-        - name: grow_policy
-          value: depthwise
-        - name: lambda_bias
-          value: '0.0'
-        - name: max_bin
-          value: '256'
-        - name: max_leaves
-          value: '0'
-        - name: normalize_type
-          value: tree
-        - name: objective
-          value: reg:linear
-        - name: one_drop
-          value: '0'
-        - name: prob_buffer_row
-          value: '1.0'
-        - name: process_type
-          value: default
-        - name: rate_drop
-          value: '0.0'
-        - name: refresh_leaf
-          value: '1'
-        - name: sample_type
-          value: uniform
-        - name: scale_pos_weight
-          value: '1.0'
-        - name: silent
-          value: '0'
-        - name: sketch_eps
-          value: '0.03'
-        - name: skip_drop
-          value: '0.0'
-        - name: tree_method
-          value: auto
-        - name: tweedie_variance_power
-          value: '1.5'
-        - name: updater
-          value: grow_colmaker,prune
-      algorithmSpecification:
-        trainingImage: 763104351884.dkr.ecr.us-west-2.amazonaws.com/tensorflow-training:2.0.1-gpu-py36-cu100-ubuntu18.04
-        trainingInputMode: File
-        metricDefinitions:
-        - name: validation:error
-          regex: "validation_error=(.*?);"
-      roleArn: {ROLE_ARN}
-      inputDataConfig:
-      - channelName: train
-        dataSource:
-          s3DataSource:
-            s3DataType: S3Prefix
-            s3Uri: s3://{DATA_BUCKET}/train/
-            s3DataDistributionType: FullyReplicated
-        contentType: text/csv
-        compressionType: None
-        recordWrapperType: None
-        inputMode: File
-      - channelName: validation
-        dataSource:
-          s3DataSource:
-            s3DataType: S3Prefix
-            s3Uri: s3://{DATA_BUCKET}/validation/
-            s3DataDistributionType: FullyReplicated
-        contentType: text/csv
-        compressionType: None
-        recordWrapperType: None
-        inputMode: File
-      outputDataConfig:
-        s3OutputPath: s3://{DATA_BUCKET}/xgboost
-      resourceConfig:
-        instanceType: ml.m4.xlarge
-        instanceCount: 1
-        volumeSizeInGB: 25
-      stoppingCondition:
-        maxRuntimeInSeconds: 3600
-      enableNetworkIsolation: true
-      enableInterContainerTrafficEncryption: false
+  region: us-west-2
+  tags:
+  - key: test-key
+    value: test-value
+  hyperParameterTuningJobConfig:
+    strategy: Bayesian
+    hyperParameterTuningJobObjective:
+      type: Minimize
+      metricName: validation:error
+    resourceLimits:
+      maxNumberOfTrainingJobs: 2
+      maxParallelTrainingJobs: 2
+    parameterRanges:
+      integerParameterRanges:
+      - name: num_round
+        minValue: '10'
+        maxValue: '20'
+        scalingType: Linear
+      continuousParameterRanges: []
+      categoricalParameterRanges: []
+    trainingJobEarlyStoppingType: Auto
+  trainingJobDefinition:
+    staticHyperParameters:
+    - name: base_score
+      value: '0.5'
+    - name: booster
+      value: gbtree
+    - name: csv_weights
+      value: '0'
+    - name: dsplit
+      value: row
+    - name: grow_policy
+      value: depthwise
+    - name: lambda_bias
+      value: '0.0'
+    - name: max_bin
+      value: '256'
+    - name: max_leaves
+      value: '0'
+    - name: normalize_type
+      value: tree
+    - name: objective
+      value: reg:linear
+    - name: one_drop
+      value: '0'
+    - name: prob_buffer_row
+      value: '1.0'
+    - name: process_type
+      value: default
+    - name: rate_drop
+      value: '0.0'
+    - name: refresh_leaf
+      value: '1'
+    - name: sample_type
+      value: uniform
+    - name: scale_pos_weight
+      value: '1.0'
+    - name: silent
+      value: '0'
+    - name: sketch_eps
+      value: '0.03'
+    - name: skip_drop
+      value: '0.0'
+    - name: tree_method
+      value: auto
+    - name: tweedie_variance_power
+      value: '1.5'
+    - name: updater
+      value: grow_colmaker,prune
+    algorithmSpecification:
+      trainingImage: 763104351884.dkr.ecr.us-west-2.amazonaws.com/tensorflow-training:2.0.1-gpu-py36-cu100-ubuntu18.04
+      trainingInputMode: File
+      metricDefinitions:
+      - name: validation:error
+        regex: "validation_error=(.*?);"
+    roleArn: {ROLE_ARN}
+    inputDataConfig:
+    - channelName: train
+      dataSource:
+        s3DataSource:
+          s3DataType: S3Prefix
+          s3Uri: s3://{DATA_BUCKET}/train/
+          s3DataDistributionType: FullyReplicated
+      contentType: text/csv
+      compressionType: None
+      recordWrapperType: None
+      inputMode: File
+    - channelName: validation
+      dataSource:
+        s3DataSource:
+          s3DataType: S3Prefix
+          s3Uri: s3://{DATA_BUCKET}/validation/
+          s3DataDistributionType: FullyReplicated
+      contentType: text/csv
+      compressionType: None
+      recordWrapperType: None
+      inputMode: File
+    outputDataConfig:
+      s3OutputPath: s3://{DATA_BUCKET}/xgboost
+    resourceConfig:
+      instanceType: ml.m4.xlarge
+      instanceCount: 1
+      volumeSizeInGB: 25
+    stoppingCondition:
+      maxRuntimeInSeconds: 3600
+    enableNetworkIsolation: true
+    enableInterContainerTrafficEncryption: false

--- a/tests/codebuild/testfiles/failing-xgboost-mnist-trainingjob.yaml
+++ b/tests/codebuild/testfiles/failing-xgboost-mnist-trainingjob.yaml
@@ -1,3 +1,7 @@
+# This TrainingJob was designed to fail during the "Training" phase.
+# The image specified refers to a plain Tensorflow DLC image that does not have
+# the correct entrypoint for a SageMaker training job. This will fail with a 
+# python exception that should be captured by the operator.
 apiVersion: sagemaker.aws.amazon.com/v1
 kind: TrainingJob
 metadata:

--- a/tests/codebuild/testfiles/failing-xgboost-mnist-trainingjob.yaml
+++ b/tests/codebuild/testfiles/failing-xgboost-mnist-trainingjob.yaml
@@ -1,0 +1,55 @@
+apiVersion: sagemaker.aws.amazon.com/v1
+kind: TrainingJob
+metadata:
+  name: failing-xgboost-mnist
+spec:
+  hyperParameters:
+    - name: max_depth
+      value: "5"
+    - name: eta
+       value: "0.2"
+     - name: gamma
+       value: "4"
+     - name: min_child_weight
+       value: "6"
+     - name: silent
+       value: "0"
+     - name: objective
+       value: multi:softmax
+     - name: num_class
+       value: "10"
+     - name: num_round
+       value: "10"
+   algorithmSpecification:
+     trainingImage: 763104351884.dkr.ecr.us-west-2.amazonaws.com/tensorflow-training:2.0.1-gpu-py36-cu100-ubuntu18.04
+     trainingInputMode: File
+   roleArn: {ROLE_ARN}
+   region: us-west-2
+   outputDataConfig:
+     s3OutputPath: s3://(DATA_BUCKET}/xgboost/
+   resourceConfig:
+     instanceCount: 1
+     instanceType: ml.m4.xlarge
+     volumeSizeInGB: 5
+   stoppingCondition:
+     maxRuntimeInSeconds: 86400
+   inputDataConfig:
+     - channelName: train
+       dataSource:
+         s3DataSource:
+           s3DataType: S3Prefix
+           s3Uri: s3://(DATA_BUCKET}/train/
+           s3DataDistributionType: FullyReplicated
+       contentType: text/csv
+       compressionType: None
+     - channelName: validation
+       dataSource:
+         s3DataSource:
+           s3DataType: S3Prefix
+           s3Uri: s3://(DATA_BUCKET}/validation/
+           s3DataDistributionType: FullyReplicated
+       contentType: text/csv
+       compressionType: None
+   tags:
+     - key: tagKey
+       value: tagValue

--- a/tests/codebuild/testfiles/failing-xgboost-mnist-trainingjob.yaml
+++ b/tests/codebuild/testfiles/failing-xgboost-mnist-trainingjob.yaml
@@ -7,49 +7,49 @@ spec:
     - name: max_depth
       value: "5"
     - name: eta
-       value: "0.2"
-     - name: gamma
-       value: "4"
-     - name: min_child_weight
-       value: "6"
-     - name: silent
-       value: "0"
-     - name: objective
-       value: multi:softmax
-     - name: num_class
-       value: "10"
-     - name: num_round
-       value: "10"
-   algorithmSpecification:
-     trainingImage: 763104351884.dkr.ecr.us-west-2.amazonaws.com/tensorflow-training:2.0.1-gpu-py36-cu100-ubuntu18.04
-     trainingInputMode: File
-   roleArn: {ROLE_ARN}
-   region: us-west-2
-   outputDataConfig:
-     s3OutputPath: s3://(DATA_BUCKET}/xgboost/
-   resourceConfig:
-     instanceCount: 1
-     instanceType: ml.m4.xlarge
-     volumeSizeInGB: 5
-   stoppingCondition:
-     maxRuntimeInSeconds: 86400
-   inputDataConfig:
-     - channelName: train
-       dataSource:
-         s3DataSource:
-           s3DataType: S3Prefix
-           s3Uri: s3://(DATA_BUCKET}/train/
-           s3DataDistributionType: FullyReplicated
-       contentType: text/csv
-       compressionType: None
-     - channelName: validation
-       dataSource:
-         s3DataSource:
-           s3DataType: S3Prefix
-           s3Uri: s3://(DATA_BUCKET}/validation/
-           s3DataDistributionType: FullyReplicated
-       contentType: text/csv
-       compressionType: None
-   tags:
-     - key: tagKey
-       value: tagValue
+      value: "0.2"
+    - name: gamma
+      value: "4"
+    - name: min_child_weight
+      value: "6"
+    - name: silent
+      value: "0"
+    - name: objective
+      value: multi:softmax
+    - name: num_class
+      value: "10"
+    - name: num_round
+      value: "10"
+  algorithmSpecification:
+    trainingImage: 763104351884.dkr.ecr.us-west-2.amazonaws.com/tensorflow-training:2.0.1-gpu-py36-cu100-ubuntu18.04
+    trainingInputMode: File
+  roleArn: {ROLE_ARN}
+  region: us-west-2
+  outputDataConfig:
+    s3OutputPath: s3://{DATA_BUCKET}/xgboost/
+  resourceConfig:
+    instanceCount: 1
+    instanceType: ml.m4.xlarge
+    volumeSizeInGB: 5
+  stoppingCondition:
+    maxRuntimeInSeconds: 86400
+  inputDataConfig:
+    - channelName: train
+      dataSource:
+        s3DataSource:
+          s3DataType: S3Prefix
+          s3Uri: s3://{DATA_BUCKET}/train/
+          s3DataDistributionType: FullyReplicated
+      contentType: text/csv
+      compressionType: None
+    - channelName: validation
+      dataSource:
+        s3DataSource:
+          s3DataType: S3Prefix
+          s3Uri: s3://{DATA_BUCKET}/validation/
+          s3DataDistributionType: FullyReplicated
+      contentType: text/csv
+      compressionType: None
+  tags:
+    - key: tagKey
+      value: tagValue


### PR DESCRIPTION
### What does this PR do / how does this improve the operators?
Runtime failures were not being propagated into the "Additional" field in the status for TrainingJob. This fix ensures any "FailureReason" in the TrainingJobDescription is placed into this field.

### Which issue(s) does this PR fix?
Fixes #
N/A

### Special notes for the reviewer:
Also modified local-run integration tests to allow for using an existing development cluster (running the operator locally using `make run`)

### Does this PR require changes to documentation?
No

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you written or refactored unit tests to cover the change?
* [x] Have you ran all unit tests and ensured they are passing?
* [x] Have you manually tested each feature that is being added/modified?
* [x] Have you ensured you have not introduced linting errors?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.