### PR TITLE
Remove container `latest` tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Image URL to use all building/pushing image targets
-IMG ?= 957583890962.dkr.ecr.us-east-1.amazonaws.com/amazon-sagemaker-operator-for-k8s:latest
+IMG ?= 957583890962.dkr.ecr.us-east-1.amazonaws.com/amazon-sagemaker-operator-for-k8s:v1
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true"
 

--- a/codebuild/scripts/package_operators.sh
+++ b/codebuild/scripts/package_operators.sh
@@ -34,23 +34,18 @@ function deploy_from_alpha()
   # Login to the prod repository
   $(aws ecr get-login --no-include-email --region ${account_region} --registry-ids ${account_id})
 
-  # Clone the controller image to the repo and set as latest
+  # Clone the controller image to the repo
   docker tag $alpha_ecr_image:$CODEBUILD_RESOLVED_SOURCE_VERSION ${dest_ecr_image}:$CODEBUILD_RESOLVED_SOURCE_VERSION
-  docker tag $alpha_ecr_image:$CODEBUILD_RESOLVED_SOURCE_VERSION ${dest_ecr_image}:latest
 
   # Push to the prod region
   docker push ${dest_ecr_image}:$CODEBUILD_RESOLVED_SOURCE_VERSION
-  docker push ${dest_ecr_image}:latest
 
   printf -v bucket_name $RELEASE_BUCKET_NAME_FMT $RELEASE_TARBALL_BUCKET_PREFIX $account_region
   printf -v binary_prefix $RELEASE_BINARY_PREFIX_FMT $bucket_name
 
-  # Copy across the binaries and set as latest
+  # Copy across the binaries
   aws s3 cp "$ALPHA_LINUX_BINARY_PATH" "$(printf $RELEASE_LINUX_BINARY_PATH_FMT $binary_prefix $CODEBUILD_RESOLVED_SOURCE_VERSION)" $PUBLIC_CP_ARGS
-  aws s3 cp "$ALPHA_LINUX_BINARY_PATH" "$(printf $RELEASE_LINUX_BINARY_PATH_FMT $binary_prefix latest)" $PUBLIC_CP_ARGS
-
   aws s3 cp "$ALPHA_DARWIN_BINARY_PATH" "$(printf $RELEASE_DARWIN_BINARY_PATH_FMT $binary_prefix $CODEBUILD_RESOLVED_SOURCE_VERSION)" $PUBLIC_CP_ARGS
-  aws s3 cp "$ALPHA_DARWIN_BINARY_PATH" "$(printf $RELEASE_DARWIN_BINARY_PATH_FMT $binary_prefix latest)" $PUBLIC_CP_ARGS
 }
 
 # This function builds, packages and deploys a region-specific operator to an ECR repo and output bucket.

--- a/codebuild/scripts/package_operators.sh
+++ b/codebuild/scripts/package_operators.sh
@@ -36,6 +36,10 @@ function deploy_from_alpha()
 
   # Clone the controller image to the repo
   docker tag $alpha_ecr_image:$CODEBUILD_RESOLVED_SOURCE_VERSION ${dest_ecr_image}:$CODEBUILD_RESOLVED_SOURCE_VERSION
+  # TODO: Remove at the time of the next major version release
+  # This moves the `latest` tag along with master branch, which will cause backwards incompatibility for any major
+  # version updates.
+  docker tag $alpha_ecr_image:$CODEBUILD_RESOLVED_SOURCE_VERSION ${dest_ecr_image}:latest
 
   # Push to the prod region
   docker push ${dest_ecr_image}:$CODEBUILD_RESOLVED_SOURCE_VERSION
@@ -43,7 +47,6 @@ function deploy_from_alpha()
   printf -v bucket_name $RELEASE_BUCKET_NAME_FMT $RELEASE_TARBALL_BUCKET_PREFIX $account_region
   printf -v binary_prefix $RELEASE_BINARY_PREFIX_FMT $bucket_name
 
-  # Copy across the binaries
   aws s3 cp "$ALPHA_LINUX_BINARY_PATH" "$(printf $RELEASE_LINUX_BINARY_PATH_FMT $binary_prefix $CODEBUILD_RESOLVED_SOURCE_VERSION)" $PUBLIC_CP_ARGS
   aws s3 cp "$ALPHA_DARWIN_BINARY_PATH" "$(printf $RELEASE_DARWIN_BINARY_PATH_FMT $binary_prefix $CODEBUILD_RESOLVED_SOURCE_VERSION)" $PUBLIC_CP_ARGS
 }

--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -10,7 +10,7 @@ patchesStrategicMerge:
 images:
 - name: controller
   newName: 957583890962.dkr.ecr.us-east-1.amazonaws.com/amazon-sagemaker-operator-for-k8s
-  newTag: latest
+  newTag: v1
 resources:
 - ../crd
 - ../rbac

--- a/hack/charts/installer/rolebased/values.yaml
+++ b/hack/charts/installer/rolebased/values.yaml
@@ -2,5 +2,5 @@ roleArn: arn:aws:iam::123456789012:role/DELETE_ME
 
 image:
   repository: 957583890962.dkr.ecr.us-east-1.amazonaws.com/amazon-sagemaker-operator-for-k8s
-  tag: latest
+  tag: v1
 

--- a/release/rolebased/installer.yaml
+++ b/release/rolebased/installer.yaml
@@ -4011,7 +4011,7 @@ spec:
         env:
         - name: AWS_DEFAULT_SAGEMAKER_ENDPOINT
           value: ""
-        image: 957583890962.dkr.ecr.us-east-1.amazonaws.com/amazon-sagemaker-operator-for-k8s:latest
+        image: 957583890962.dkr.ecr.us-east-1.amazonaws.com/amazon-sagemaker-operator-for-k8s:v1
         imagePullPolicy: Always
         name: manager
         resources:


### PR DESCRIPTION
### What does this PR do / how does this improve the operators?
Removes any reference to the `latest` tag from our installation methods, and from the CD release scripts. Currently, if we were to push a major version update to the master branch, all valid installations would break due to backwards compatibility breaking from v1 to v2. This fix mitigates that by removing access to the `latest` tag, and recommending the latest major version tag as the default installation method.

### Which issue(s) does this PR fix?

Fixes # N/A

### Special notes for the reviewer:

### Does this PR require changes to documentation?

### All Submissions:

* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you written or refactored unit tests to cover the change?
* [ ] Have you ran all unit tests and ensured they are passing?
* [ ] Have you manually tested each feature that is being added/modified?
* [ ] Have you ensured you have not introduced linting errors?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.