### PR TITLE
Fixing integ test bug

### DIFF
--- a/tests/codebuild/create_tests.sh
+++ b/tests/codebuild/create_tests.sh
@@ -89,7 +89,7 @@ function verify_debug_test
 
   echo "Waiting for debug job to finish"
   timeout "${timeout}" bash -c \
-    'until [ "$(kubectl get "$0" "$1" -o json | jq -r .status.debugRuleEvaluationStatuses[0].ruleEvaluationStatus)" != "$2" ]; do \
+    'until [ "$(kubectl get "$0" "$1" -o json | jq -r .status.debugRuleEvaluationStatuses[0].ruleEvaluationStatus)" == "$2" ]; do \
       echo "Debug job has not completed yet"; \
       sleep 1; \
     done' "${crd_type}" "${crd_instance}" "${expected_debug_job_status}"


### PR DESCRIPTION
### What does this PR do / how does this improve the operators?
This PR fixes the bug in integ test. 

### Which issue(s) does this PR fix?
```
agent_1  | Waiting for job to complete
agent_1  | [PASSED] Verified TrainingJob xgboost-mnist-debugger has completed
agent_1  | NAME                     STATUS      SECONDARY-STATUS   CREATION-TIME          SAGEMAKER-JOB-NAME
agent_1  | xgboost-mnist-debugger   Completed   Completed          2020-03-25T00:08:58Z   xgboost-mnist-debugger-d2ff61bf6e2c11ea94080a9ec385c3a0
agent_1  | Waiting for job to start
agent_1  | Waiting for job to complete
agent_1  | [PASSED] Verified TrainingJob xgboost-mnist-debugger has completed
agent_1  | Waiting for debug job to finish
agent_1  | Debug job has completed
agent_1  | Verifying feature integration tests
agent_1  | Verifying feature canary tests

```
Fixes #

### Special notes for the reviewer:

### Does this PR require changes to documentation?

### All Submissions:

* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you written or refactored unit tests to cover the change?
* [ ] Have you ran all unit tests and ensured they are passing?
* [ ] Have you manually tested each feature that is being added/modified?
* [ ] Have you ensured you have not introduced linting errors?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.