### PR TITLE
Integ Tests for namespace deployment and automated OIDC IAM role generation

### DIFF
--- a/scripts/generate_iam_role.sh
+++ b/scripts/generate_iam_role.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+# Helper script to generate an IAM Role needed to install operator using role-based authentication.
+# https://sagemaker.readthedocs.io/en/stable/amazon_sagemaker_operators_for_kubernetes.html#create-an-iam-role
+#
+# Run as:
+# $ ./generate_iam_role.sh ${cluster_arn} ${operator_namespace} ${role_name}
+#
+
+CLUSTER_ARN=${1}
+OPERATOR_NAMESPACE=${2}
+ROLE_NAME=${3}
+aws_account=$(aws sts get-caller-identity --query Account --output text)
+trustfile="trust.json"
+
+# Use the cluster arn to get the region and cluster name
+# example, cluster_arn=arn:aws:eks:us-east-1:12345678910:cluster/test
+cluster_name=$(echo ${CLUSTER_ARN} | cut -d'/' -f2)
+cluster_region=$(echo ${CLUSTER_ARN} | cut -d':' -f4)
+
+# A function to get the OIDC_ID associated with an EKS cluster
+function get_oidc_id {
+    # TODO: Ideally this should be based on version compatibility instead of command failure
+    eksctl utils associate-iam-oidc-provider --cluster ${cluster_name} --region ${cluster_region} --approve
+    if [[ $? -ge 1 ]]; then
+        eksctl utils associate-iam-oidc-provider --name ${cluster_name} --region ${cluster_region} --approve
+    fi
+    
+    local oidc=$(aws eks describe-cluster --name ${cluster_name} --region ${cluster_region} --query cluster.identity.oidc.issuer --output text)
+    oidc_id=$(echo ${oidc} | rev | cut -d'/' -f1 | rev)
+}
+
+# A function that generates an IAM role for the given account, cluster, namespace, region
+function create_namespaced_iam_role {
+    # Check if role already exists
+    aws iam get-role --role-name ${ROLE_NAME}
+    if [[ $? -eq 0 ]]; then
+        echo "A role for this cluster and namespace already exists in this account, assuming sagemaker access and proceeding."
+    else
+        echo "IAM Role does not exist, creating a new Role for the cluster"
+        aws iam create-role --role-name ${ROLE_NAME} --assume-role-policy-document file://${trustfile} --output=text
+        aws iam attach-role-policy --role-name ${ROLE_NAME}  --policy-arn arn:aws:iam::aws:policy/AmazonSageMakerFullAccess
+    fi
+}
+
+# Remove the generated trust file
+function cleanup {
+    rm ${trustfile} 
+}
+
+echo "Get the OIDC ID for the cluster"
+get_oidc_id
+echo "Delete the trust json file if it already exists"
+cleanup
+echo "Generate a trust json"
+./generate_trust_policy.sh ${cluster_region} ${aws_account} ${oidc_id} ${OPERATOR_NAMESPACE} > "${trustfile}"
+echo "Create the IAM Role using these values"
+create_namespaced_iam_role
+echo "Cleanup for the next run!"
+cleanup
+

--- a/scripts/generate_trust_policy.sh
+++ b/scripts/generate_trust_policy.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# Helper script to generate trust policy needed to install operator using role-based authentication.
+# https://sagemaker.readthedocs.io/en/stable/amazon_sagemaker_operators_for_kubernetes.html#create-an-iam-role
+#
+# Run as:
+# $ ./generate_trust_policy ${EKS_CLUSTER_REGION} ${AWS_ACCOUNT_ID} ${OIDC_ID} [optional: ${OPERATOR_NAMESPACE}] > trust.json
+#
+# For example:
+# $ ./generate_trust_policy us-west-2 123456789012 D48675832CA65BD10A532F597OIDCID > trust.json
+# This will create a file `trust.json` containing a role policy that enables the operator in an EKS cluster to assume AWS roles.
+#
+# The OPERATOR_NAMESPACE parameter is for when you want to run the operator in a custom namespace other than "sagemaker-k8s-operator-system".
+
+cluster_region="$1"
+account_number="$2"
+oidc_id="$3"
+operator_namespace="${4:-sagemaker-k8s-operator-system}"
+
+printf '{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::'"${account_number}"':oidc-provider/oidc.eks.'"${cluster_region}"'.amazonaws.com/id/'"${oidc_id}"'"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "oidc.eks.'"${cluster_region}"'.amazonaws.com/id/'"${oidc_id}"':aud": "sts.amazonaws.com",
+          "oidc.eks.'"${cluster_region}"'.amazonaws.com/id/'"${oidc_id}"':sub": "system:serviceaccount:'"${operator_namespace}"':sagemaker-k8s-operator-default"
+        }
+      }
+    }
+  ]
+}
+'

--- a/tests/codebuild/common.sh
+++ b/tests/codebuild/common.sh
@@ -1,42 +1,51 @@
 #!/bin/bash
 
-# Create a resource (run a test) given a specification yaml.
-# Parameter: $1 filename of test
+# Create a resource (run a test) given a specification within a given namespace.
+# Parameter:
+#    $1: Target namespace
+#    $2: Filename of the test
 function run_test()
 {
-  kubectl apply -f "$1"
+  local target_namespace="$1"
+  local file_name="$2"
+
+  kubectl apply -n "$target_namespace" -f "$file_name"
 }
 
 # This function gets the sagemaker model name from k8s model
 # Parameter:
-#    $1: Name of k8s model
-# e.g. get_sagemaker_model_from_k8s_model k8s_model 
+#    $1: Namespace of the k8s model
+#    $2: Name of k8s model
+# e.g. get_sagemaker_model_from_k8s_model default k8s_model 
 function get_sagemaker_model_from_k8s_model()
 {
-  local k8s_model_name="$1"
+  local model_namespace="$1"
+  local k8s_model_name="$2"
   # Get the second line and 3rd column, since valid output will be following
   # NAME                    STATUS    SAGE-MAKER-MODEL-NAME
   # xgboost-model           Created   model-5c06b18921e411ea91230292f5024981
-  kubectl get model $k8s_model_name | sed -n '2 p' |  awk '{print $3}' 
+  kubectl get -n "${model_namespace}" model "${k8s_model_name}" | sed -n '2 p' |  awk '{print $3}' 
 }
 
 # This function waits until a CRD has reached a particular state, or times out
 # Parameter:
-#    $1: Kind of CRD
-#    $2: Instance of CRD
-#    $3: Timeout to complete the test
-#    $4: The status that verifies the job has succeeded.
+#    $1: Namespace of CRD
+#    $2: Kind of CRD
+#    $3: Instance of CRD
+#    $4: Timeout to complete the test
+#    $5: The status that verifies the job has succeeded.
 function wait_for_crd_status()
 {
-  local crd_type="$1"
-  local crd_instance="$2"
-  local timeout="$3"
-  local desired_status="$4"
+  local crd_namespace="$1"
+  local crd_type="$2"
+  local crd_instance="$3"
+  local timeout="$4"
+  local desired_status="$5"
 
   timeout "${timeout}" bash -c \
-    'until [ "$(kubectl get "$0" "$1" -o=custom-columns=STATUS:.status | grep -i "$2" | wc -l)" -eq "1" ]; do \
+    'until [ "$(kubectl get -n "$0" "$1" "$2" -o=custom-columns=STATUS:.status | grep -i "$3" | wc -l)" -eq "1" ]; do \
       sleep 5; \
-    done' "$crd_type" "$crd_instance" "$desired_status"
+    done' "$crd_namespace" "$crd_type" "$crd_instance" "$desired_status"
 
   if [ $? -ne 0 ]; then
     return 1

--- a/tests/codebuild/common.sh
+++ b/tests/codebuild/common.sh
@@ -55,9 +55,10 @@ function wait_for_crd_status()
 # Cleans up all resources created during tests.
 function delete_all_resources()
 {
-  kubectl delete hyperparametertuningjob --all
-  kubectl delete trainingjob --all
-  kubectl delete batchtransformjob --all
-  kubectl delete hostingdeployment --all
-  kubectl delete model --all
+  local crd_namespace="$1"
+  kubectl delete -n "$crd_namespace" hyperparametertuningjob --all 
+  kubectl delete -n "$crd_namespace" trainingjob --all
+  kubectl delete -n "$crd_namespace" batchtransformjob --all
+  kubectl delete -n "$crd_namespace" hostingdeployment --all 
+  kubectl delete -n "$crd_namespace" model --all 
 }

--- a/tests/codebuild/common.sh
+++ b/tests/codebuild/common.sh
@@ -53,6 +53,8 @@ function wait_for_crd_status()
 }
 
 # Cleans up all resources created during tests.
+# Parameter:
+#    $1: Namespace of CRD
 function delete_all_resources()
 {
   local crd_namespace="$1"

--- a/tests/codebuild/create_tests.sh
+++ b/tests/codebuild/create_tests.sh
@@ -99,7 +99,7 @@ function verify_debug_test
   local timeout="$4"
   local expected_debug_job_status="$5"
   # First verify that trainingjob has been completed
-  verify_test TrainingJob xgboost-mnist-debugger $timeout Completed
+  verify_test "${crd_namespace}" TrainingJob xgboost-mnist-debugger $timeout Completed
 
   # TODO extend this for multiple debug job with debug job statuses parameter
 

--- a/tests/codebuild/feature_tests.sh
+++ b/tests/codebuild/feature_tests.sh
@@ -11,6 +11,8 @@ function run_feature_canary_tests
 }
 
 # Applies each of the resources needed for the integration tests.
+# Parameter:
+#    $1: CRD namespace
 function run_feature_integration_tests
 {
   echo "Running feature integration tests"
@@ -23,6 +25,8 @@ function run_feature_integration_tests
 
 # Creates a training job in the specified namespace
 # For this test, the job is created in a namespace that does not have the operator. 
+# Parameter:
+#    $1: CRD namespace
 function run_feature_namespaced_tests
 {
   echo "Running feature namespaced tests"
@@ -32,6 +36,8 @@ function run_feature_namespaced_tests
 }
 
 # Verifies that the job created in an incorrect namespace does not gain a status or sagemaker name.
+# Parameter:
+#    $1: CRD namespace
 function verify_feature_namespaced_tests
 {
   echo "Verifying namespace deployment test"
@@ -49,6 +55,8 @@ function verify_feature_canary_tests
 }
 
 # Verifies that each integration feature test has completed successfully.
+# Parameter:
+#    $1: CRD namespace
 function verify_feature_integration_tests
 {
   echo "Verifying feature integration tests"

--- a/tests/codebuild/feature_tests.sh
+++ b/tests/codebuild/feature_tests.sh
@@ -16,8 +16,8 @@ function run_feature_integration_tests
   echo "Running feature integration tests"
   run_feature_canary_tests
 
-  run_test testfiles/failing-xgboost-mnist-hpo.yaml
-  run_test testfiles/failing-xgboost-mnist-trainingjob.yaml
+  run_test default testfiles/failing-xgboost-mnist-hpo.yaml
+  run_test default testfiles/failing-xgboost-mnist-trainingjob.yaml
 }
 
 # Verify that each canary feature test has completed successfully.
@@ -32,25 +32,25 @@ function verify_feature_integration_tests
   echo "Verifying feature integration tests"
   verify_feature_canary_tests
 
-  if ! wait_for_crd_status TrainingJob failing-xgboost-mnist 5m Failed; then
+  if ! wait_for_crd_status "$crd_namespace" TrainingJob failing-xgboost-mnist 5m Failed; then
     echo "[FAILED] Failing training job never reached status Failed"
     exit 1
   fi
-  if ! verify_resource_has_additional TrainingJob failing-xgboost-mnist; then
+  if ! verify_resource_has_additional "$crd_namespace" TrainingJob failing-xgboost-mnist; then
     echo "[FAILED] Failing training job does not have any additional status set" 
     exit 1
   fi
   echo "[SUCCESS] TrainingJob with Failed status has additional set"
 
-  if ! wait_for_crd_status HyperParameterTuningJob failing-xgboost-mnist-hpo 10m Failed; then
+  if ! wait_for_crd_status "$crd_namespace" HyperParameterTuningJob failing-xgboost-mnist-hpo 10m Failed; then
     echo "[FAILED] Failing hyperparameter tuning job never reached status Failed"
     exit 1
   fi
-  if ! verify_resource_has_additional HyperParameterTuningJob failing-xgboost-mnist-hpo; then
+  if ! verify_resource_has_additional "$crd_namespace" HyperParameterTuningJob failing-xgboost-mnist-hpo; then
     echo "[FAILED] Failing hyperparameter tuning job does not have any additional status set"
     exit 1
   fi
-  if ! verify_failed_trainingjobs_from_hpo_have_additional failing-xgboost-mnist-hpo; then
+  if ! verify_failed_trainingjobs_from_hpo_have_additional "$crd_namespace" failing-xgboost-mnist-hpo; then
     echo "[FAILED] Not all failed training jobs in failing HPO job contained the additional in their statuses"
     exit 1
   fi
@@ -60,13 +60,15 @@ function verify_feature_integration_tests
 # This function verifies that a given training job has a failure reason in the 
 # additional part of the status.
 # Parameter:
-#    $1: CRD type
-#    $2: Instance of CRD
+#    $1: CRD namespace
+#    $2: CRD type
+#    $3: Instance of CRD
 function verify_resource_has_additional
 {
-  local crd_type="$1"
-  local crd_instance="$2"
-  local additional="$(kubectl get "$crd_type" "$crd_instance" -o json | jq -r '.status.additional')"
+  local crd_namespace="$1"
+  local crd_type="$2"
+  local crd_instance="$3"
+  local additional="$(kubectl get -n "$crd_namespace" "$crd_type" "$crd_instance" -o json | jq -r '.status.additional')"
 
   if [ -z "$additional" ]; then
     return 1
@@ -76,16 +78,18 @@ function verify_resource_has_additional
 # This function verifies that each Failed trainingjob for a given HPO job have
 # the additional field in their status set.
 # Parameter:
-#    $1: Instance of HyperParameterTuningJob
+#    $1: Job namespace
+#    $2: Instance of HyperParameterTuningJob
 function verify_failed_trainingjobs_from_hpo_have_additional
 {
-  local crd_instance="$1"
+  local crd_namespace="$1"
+  local crd_instance="$2"
 
-  local sagemaker_hpo_job_name="$(kubectl get hyperparametertuningjob "$crd_instance" -o json | jq -r '.status.sageMakerHyperParameterTuningJobName')"
+  local sagemaker_hpo_job_name="$(kubectl get -n "$crd_namespace" hyperparametertuningjob "$crd_instance" -o json | jq -r '.status.sageMakerHyperParameterTuningJobName')"
 
   # Loop over every failed training job and get the k8s resource name
-  for training_job in $(kubectl get trainingjob | grep Failed | grep "$sagemaker_hpo_job_name" | awk '{print $1}'); do
-    if ! verify_resource_has_additional TrainingJob "$training_job"; then
+  for training_job in $(kubectl get -n "$crd_namespace" trainingjob | grep Failed | grep "$sagemaker_hpo_job_name" | awk '{print $1}'); do
+    if ! verify_resource_has_additional "$crd_namespace" TrainingJob "$training_job"; then
       return 1
     fi
   done

--- a/tests/codebuild/feature_tests.sh
+++ b/tests/codebuild/feature_tests.sh
@@ -14,10 +14,11 @@ function run_feature_canary_tests
 function run_feature_integration_tests
 {
   echo "Running feature integration tests"
+  local crd_namespace="$1"
   run_feature_canary_tests
 
-  run_test default testfiles/failing-xgboost-mnist-hpo.yaml
-  run_test default testfiles/failing-xgboost-mnist-trainingjob.yaml
+  run_test "${crd_namespace}" testfiles/failing-xgboost-mnist-hpo.yaml
+  run_test "${crd_namespace}" testfiles/failing-xgboost-mnist-trainingjob.yaml
 }
 
 # Verify that each canary feature test has completed successfully.
@@ -30,6 +31,7 @@ function verify_feature_canary_tests
 function verify_feature_integration_tests
 {
   echo "Verifying feature integration tests"
+  local crd_namespace="$1"
   verify_feature_canary_tests
 
   if ! wait_for_crd_status "$crd_namespace" TrainingJob failing-xgboost-mnist 5m Failed; then

--- a/tests/codebuild/feature_tests.sh
+++ b/tests/codebuild/feature_tests.sh
@@ -37,7 +37,7 @@ function verify_feature_namespaced_tests
   echo "Verifying namespace deployment test"
   local crd_namespace="$1"
   if ! verify_trainingjob_has_no_sagemaker_name "$crd_namespace" TrainingJob "xgboost-mnist"; then
-    echo "[FAILED] TrainingJob deployed to default namespace was created" 
+    echo "[FAILED] TrainingJob deployed to $crd_namespace namespace was created" 
     exit 1
   fi
 }

--- a/tests/codebuild/inject_tests.sh
+++ b/tests/codebuild/inject_tests.sh
@@ -32,4 +32,5 @@ function inject_all_variables
   inject_variables testfiles/failing-xgboost-mnist-trainingjob.yaml
   inject_variables testfiles/failing-xgboost-mnist-hpo.yaml
   inject_variables testfiles/xgboost-mnist-trainingjob-debugger.yaml
+  inject_variables testfiles/xgboost-mnist-trainingjob-namespaced.yaml
 }

--- a/tests/codebuild/run_all_sample_canary_tests.sh
+++ b/tests/codebuild/run_all_sample_canary_tests.sh
@@ -6,10 +6,10 @@ source delete_tests.sh
 source inject_tests.sh
 source smlogs_tests.sh
 
-run_canary_tests
-run_feature_canary_tests
-verify_canary_tests
-verify_feature_canary_tests
-run_smlogs_canary_tests
-delete_all_resources # Delete all existing resources to re-use metadata names
-run_delete_canary_tests
+run_canary_tests "default"
+run_feature_canary_tests "default"
+verify_canary_tests "default"
+verify_feature_canary_tests "default"
+run_smlogs_canary_tests "default"
+delete_all_resources "default" # Delete all existing resources to re-use metadata names
+run_delete_canary_tests "default" 

--- a/tests/codebuild/run_all_sample_namespace_tests.sh
+++ b/tests/codebuild/run_all_sample_namespace_tests.sh
@@ -3,10 +3,13 @@
 source create_tests.sh
 source delete_tests.sh
 source inject_tests.sh
+source feature_tests.sh
 
 crd_namespace="${1}"
 
 run_canary_tests "${crd_namespace}"
 verify_canary_tests "${crd_namespace}"
+run_feature_namespaced_tests "default" # Deploy job to namespace without operator.
+verify_feature_namespaced_tests "default"
 delete_all_resources "${crd_namespace}" # Delete all existing resources to re-use metadata names
 run_delete_canary_tests "${crd_namespace}"

--- a/tests/codebuild/run_all_sample_namespace_tests.sh
+++ b/tests/codebuild/run_all_sample_namespace_tests.sh
@@ -6,10 +6,12 @@ source inject_tests.sh
 source feature_tests.sh
 
 crd_namespace="${1}"
+noop_namespace="noop-namespace"
 
 run_canary_tests "${crd_namespace}"
 verify_canary_tests "${crd_namespace}"
-run_feature_namespaced_tests "default" # Deploy job to namespace without operator.
-verify_feature_namespaced_tests "default"
+run_feature_namespaced_tests "${noop_namespace}" # Deploy job to namespace without operator.
+verify_feature_namespaced_tests "${noop_namespace}"
 delete_all_resources "${crd_namespace}" # Delete all existing resources to re-use metadata names
+delete_all_resources "${noop_namespace}"
 run_delete_canary_tests "${crd_namespace}"

--- a/tests/codebuild/run_all_sample_namespace_tests.sh
+++ b/tests/codebuild/run_all_sample_namespace_tests.sh
@@ -10,8 +10,8 @@ noop_namespace="noop-namespace"
 
 run_canary_tests "${crd_namespace}"
 verify_canary_tests "${crd_namespace}"
-run_feature_namespaced_tests "${noop_namespace}" # Deploy job to namespace without operator.
-verify_feature_namespaced_tests "${noop_namespace}"
+run_namespace_deployment_tests "${noop_namespace}" # Deploy job to namespace without operator.
+verify_job_fails_outside_operator_namespace "${noop_namespace}"
 delete_all_resources "${crd_namespace}" # Delete all existing resources to re-use metadata names
 delete_all_resources "${noop_namespace}"
 run_delete_canary_tests "${crd_namespace}"

--- a/tests/codebuild/run_all_sample_namespace_tests.sh
+++ b/tests/codebuild/run_all_sample_namespace_tests.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+source create_tests.sh
+source delete_tests.sh
+source inject_tests.sh
+
+crd_namespace="${1}"
+
+run_canary_tests "${crd_namespace}"
+verify_canary_tests "${crd_namespace}"
+delete_all_resources "${crd_namespace}" # Delete all existing resources to re-use metadata names
+run_delete_canary_tests "${crd_namespace}"

--- a/tests/codebuild/run_all_sample_test.sh
+++ b/tests/codebuild/run_all_sample_test.sh
@@ -6,10 +6,12 @@ source delete_tests.sh
 source inject_tests.sh
 source smlogs_tests.sh
 
-run_integration_tests
-run_feature_integration_tests
-verify_integration_tests
-verify_feature_integration_tests
-run_smlogs_integration_tests
-delete_all_resources # Delete all existing resources to re-use metadata names
-run_delete_integration_tests
+crd_namespace=${1}
+
+run_integration_tests ${crd_namespace}
+run_feature_integration_tests ${crd_namespace}
+verify_integration_tests ${crd_namespace}
+verify_feature_integration_tests ${crd_namespace}
+run_smlogs_integration_tests ${crd_namespace}
+delete_all_resources ${crd_namespace} # Delete all existing resources to re-use metadata names
+run_delete_integration_tests ${crd_namespace}

--- a/tests/codebuild/run_integtest.sh
+++ b/tests/codebuild/run_integtest.sh
@@ -132,7 +132,7 @@ else
     # Wait to increase chance that pod is ready
     # TODO: Should upgrade kubectl to version that supports `kubectl wait pods --all`
     sleep 60
-    kubectl get pods --all-namespaces | grep sagemaker
+    #kubectl get pods --all-namespaces | grep sagemaker
 fi 
 
 echo "Starting Integ Tests in default namespace"

--- a/tests/codebuild/run_integtest.sh
+++ b/tests/codebuild/run_integtest.sh
@@ -170,7 +170,7 @@ function operator_namespace_deploy {
     # Wait to increase chance that pod is ready
     # TODO: Should upgrade kubectl to version that supports `kubectl wait pods --all`
     sleep 60
-    echo "Check that the manager pod is running"
+    echo "Print manager pod status"
     kubectl get pods --all-namespaces | grep sagemaker
 }
 

--- a/tests/codebuild/run_integtest.sh
+++ b/tests/codebuild/run_integtest.sh
@@ -28,6 +28,7 @@ function cleanup_default_namespace {
     get_manager_logs
     delete_all_resources "default"
     kustomize build "$path_to_installer/config/default" | kubectl delete -f -
+    set -e
 }
 
 # A function to cleanup resources before exit. If cluster was not launched by the script, only the CRDs, jobs and operator will be deleted.
@@ -58,6 +59,7 @@ function cleanup {
     if [ "${existing_fsx}" == "false" ] && [ "$FSX_ID" != "" ]; then
         aws fsx --region us-west-2 delete-file-system --file-system-id "$FSX_ID"
     fi
+    set -e
 }
 
 # Set the trap to clean up resources

--- a/tests/codebuild/run_integtest.sh
+++ b/tests/codebuild/run_integtest.sh
@@ -128,7 +128,7 @@ if [ "${SKIP_INSTALLATION}" == "true" ]; then
 else
     pushd sagemaker-k8s-operator/sagemaker-k8s-operator-install-scripts
         echo "Deploying the operator to the default namespace"
-        kustomize build config/default | kubectl apply -f -
+        ##kustomize build config/default | kubectl apply -f -
     popd
     echo "Waiting for controller pod to be Ready"
     # Wait to increase chance that pod is ready
@@ -139,7 +139,7 @@ fi
 
 echo "Starting Integ Tests in default namespace"
 pushd tests/codebuild
-    ./run_all_sample_test.sh "default"
+    ##./run_all_sample_test.sh "default"
 popd
 
 echo "Skipping private link test"

--- a/tests/codebuild/run_integtest.sh
+++ b/tests/codebuild/run_integtest.sh
@@ -94,7 +94,7 @@ if [ "${need_setup_cluster}" == "true" ]; then
     readonly cluster_region="us-east-1"
 
     # By default eksctl picks random AZ, which time to time leads to capacity issue.
-    eksctl create cluster "${cluster_name}" --nodes 1 --node-type=c5.xlarge --timeout=40m --region "${cluster_region}" --zones us-east-1a,us-east-1b,us-east-1c --auto-kubeconfig --version=1.14 --fargate 
+    eksctl create cluster "${cluster_name}" --nodes 2 --node-type=c5.4xlarge --timeout=40m --region "${cluster_region}" --zones us-east-1a,us-east-1b,us-east-1c --auto-kubeconfig --version=1.14 --fargate 
     eksctl create fargateprofile --namespace sagemaker-k8s-operator-system --cluster "${cluster_name}" --name operator-profile --region "${cluster_region}"
 
     echo "Setting kubeconfig"

--- a/tests/codebuild/run_integtest.sh
+++ b/tests/codebuild/run_integtest.sh
@@ -207,6 +207,6 @@ fi
 # Run the integration test file
 echo "Starting Integ Tests for namespaced operator deployment"
 pushd tests/codebuild/ 
-    ./run_all_sample_test.sh "${crd_namespace}"
+    ./run_all_sample_namespace_tests.sh "${crd_namespace}"
 popd
 

--- a/tests/codebuild/run_integtest.sh
+++ b/tests/codebuild/run_integtest.sh
@@ -194,7 +194,7 @@ cleanup_default_namespace
 
 #Create the IAM Role for the given namespace
 generate_iam_role_name "${crd_namespace}"
-cd scripts && ./generate_iam_role.sh "${cluster_name}" "${crd_namespace}" "${role_name}" && cd ..
+cd scripts && ./generate_iam_role.sh "${cluster_name}" "${crd_namespace}" "${role_name}" "${cluster_region}" && cd ..
 
 # Allow for overriding the installation of the CRDs/controller image from the
 # build scripts if we want to use our own installation

--- a/tests/codebuild/run_integtest.sh
+++ b/tests/codebuild/run_integtest.sh
@@ -93,7 +93,7 @@ if [ "${need_setup_cluster}" == "true" ]; then
     readonly cluster_region="us-east-1"
 
     # By default eksctl picks random AZ, which time to time leads to capacity issue.
-    eksctl create cluster "${cluster_name}" --nodes 1 --node-type=c5.xlarge --timeout=40m --region "${cluster_region}" --zones us-east-1a,us-east-1b,us-east-1c --auto-kubeconfig --version=1.14 --fargate 
+    eksctl create cluster "${cluster_name}" --timeout=40m --region "${cluster_region}" --zones us-east-1a,us-east-1b,us-east-1c --auto-kubeconfig --version=1.14 --fargate 
     eksctl create fargateprofile --namespace "${crd_namespace}" --cluster "${cluster_name}" --name namespace-profile --region "${cluster_region}"
     eksctl create fargateprofile --namespace sagemaker-k8s-operator-system --cluster "${cluster_name}" --name operator-profile --region "${cluster_region}"
 

--- a/tests/codebuild/run_integtest.sh
+++ b/tests/codebuild/run_integtest.sh
@@ -6,7 +6,7 @@
 # crd_namespace is currently hardcoded here for cleanup. Should be an env variable set in the pipeline and .env file
 
 source tests/codebuild/common.sh
-crd_namespace="test-namespace"
+crd_namespace=${NAMESPACE_OVERRIDE:-"test-namespace"}
 
 # Verbose trace of commands, helpful since test iteration takes a long time.
 set -x 
@@ -34,7 +34,7 @@ function cleanup_default_namespace {
 function cleanup {
     # We want to run every command in this function, even if some fail.
     set +e
-    echo "Running final cluster cleanup, some commands may fail if resources do not exist."
+    echo "[SECTION] Running final cluster cleanup, some commands may fail if resources do not exist."
 
     get_manager_logs "${crd_namespace}"
     delete_all_resources "${crd_namespace}"
@@ -103,7 +103,7 @@ else
     readonly cluster_region="$(echo "${cluster_info}" | awk '{print $2}')"
 fi
 
-echo "SETUP FOR INTEGRATION TESTS"
+echo "[SECTION] Setup for integration tests"
 # Download the CRD from the tarball artifact bucket
 aws s3 cp s3://$ALPHA_TARBALL_BUCKET/${CODEBUILD_RESOLVED_SOURCE_VERSION}/sagemaker-k8s-operator-us-west-2-alpha.tar.gz sagemaker-k8s-operator.tar.gz 
 tar -xf sagemaker-k8s-operator.tar.gz
@@ -118,7 +118,7 @@ pushd sagemaker-k8s-operator
     popd
 popd
 
-echo "RUN INTEGRATION TESTS FOR THE CLUSTER SCOPED OPERATOR DEPLOYMENT"
+echo "[SECTION] Run integration tests for the cluster scoped operator deployment"
 # Allow for overriding the installation of the CRDs/controller image from the
 # build scripts if we want to use our own installation
 if [ "${SKIP_INSTALLATION}" == "true" ]; then
@@ -143,7 +143,7 @@ popd
 echo "Skipping private link test"
 #cd private-link-test && ./run_private_link_integration_test "${cluster_name}" "us-west-2"
 
-echo "RUN INTEGRATION TESTS FOR THE NAMESPACED OPERATOR DEPLOYMENT"
+echo "[SECTION] Run integration tests for the namespaced operator deployment"
 # A helper function to generate an IAM Role name for the current cluster and sepcified namespace
 # Parameter:
 #    $1: Namespace of CRD

--- a/tests/codebuild/run_integtest.sh
+++ b/tests/codebuild/run_integtest.sh
@@ -1,33 +1,58 @@
 #!/bin/bash
 
-source tests/codebuild/common.sh
-
 # TODOs
 # 1. Add validation for each steps and abort the test if steps fails
 # Build environment `Docker image` has all prerequisite setup and credentials are being passed using AWS system manager
+# crd_namespace is currently hardcoded here for cleanup. Should be an env variable set in the pipeline and .env file
+
+source tests/codebuild/common.sh
+crd_namespace="test-namespace"
 
 # Verbose trace of commands, helpful since test iteration takes a long time.
 set -x 
 
-# A function to delete cluster, if cluster was not launched this will fail, so test will fail ultimately too
+# A function to print the operator logs for a given namespace
+# Parameter:
+#    $1: Namespace of the operator
+function get_manager_logs {
+    local crd_namespace="${1-sagemaker-k8s-operator-system}"
+    if [ "${PRINT_DEBUG}" != "false" ]; then
+        echo "Controller manager logs in the ${crd_namespace} namespace"
+        kubectl -n "${crd_namespace}" logs "$(kubectl get pods -n "${crd_namespace}" | grep sagemaker-k8s-operator-controller-manager | awk '{print $1}')" manager
+    fi
+}
+
+# A function that cleans up Jobs, CRDs and Operator in the default namespace
+function cleanup_default_namespace {
+    set +e
+    get_manager_logs
+    delete_all_resources "default"
+    kustomize build $path_to_installer/config/default | kubectl delete -f -
+}
+
+# A function to cleanup resources before exit. If cluster was not launched by the script, only the CRDs, jobs and operator will be deleted.
 function cleanup {
     # We want to run every command in this function, even if some fail.
     set +e
+    echo "Running final cluster cleanup, some commands may fail if resources do not exist."
 
-    if [ "${PRINT_DEBUG}" != "false" ]; then
-        echo "Controller manager logs:"
-        kubectl -n sagemaker-k8s-operator-system logs "$(kubectl get pods -n sagemaker-k8s-operator-system | grep sagemaker-k8s-operator-controller-manager | awk '{print $1}')" manager
-    fi
-
-    delete_all_resources
-
+    get_manager_logs "${crd_namespace}"
+    delete_all_resources "${crd_namespace}"
+    cleanup_default_namespace
+    
     # Tear down the cluster if we set it up.
     if [ "${need_setup_cluster}" == "true" ]; then
         echo "need_setup_cluster is true, tearing down cluster we created."
         eksctl delete cluster --name "${cluster_name}" --region "${cluster_region}"
+        # Delete the role associated with the cluster thats being deleted
+        aws iam delete-role --role-name ${role_name}
     else
         echo "need_setup_cluster is not true, will remove operator without deleting cluster"
-        kustomize build bin/sagemaker-k8s-operator-install-scripts/config/default | kubectl delete -f -
+        kustomize build $path_to_installer/config/default | kubectl delete -f -
+        # Delete the namespaced operator. TODO: This can be cleaner if parameterized
+        kustomize build $path_to_installer/config/crd | kubectl delete -f -
+        generate_namespace_operator_installer ${crd_namespace}
+        kubectl delete -f temp_file.yaml    
     fi
 
     if [ "${existing_fsx}" == "false" ] && [ "$FSX_ID" != "" ]; then
@@ -78,40 +103,101 @@ else
     readonly cluster_region="$(echo "${cluster_info}" | awk '{print $2}')"
 fi
 
-
+echo "SETUP FOR INTEGRATION TESTS"
 # Download the CRD from the tarball artifact bucket
 aws s3 cp s3://$ALPHA_TARBALL_BUCKET/${CODEBUILD_RESOLVED_SOURCE_VERSION}/sagemaker-k8s-operator-us-west-2-alpha.tar.gz sagemaker-k8s-operator.tar.gz 
 tar -xf sagemaker-k8s-operator.tar.gz
-
 # Jump to the root dir of the operator
 pushd sagemaker-k8s-operator
-
-    # Setup the PATH for smlogs
+# Setup the PATH for smlogs
     mv smlogs-plugin/linux.amd64/kubectl-smlogs /usr/bin/kubectl-smlogs
-
-    # Allow for overriding the installation of the CRDs/controller image from the
-    # build scripts if we want to use our own installation
-    if [ "${SKIP_INSTALLATION}" == "true" ]; then
-        echo "Skipping installation of CRDs and operator"
-    else
-        # Goto directory that holds the CRD  
-        pushd sagemaker-k8s-operator-install-scripts
-            # Since OPERATOR_AWS_SECRET_ACCESS_KEY and OPERATOR_AWS_ACCESS_KEY_ID defined in build spec, we will not create new user
-            ./setup_awscreds
-
-            echo "Deploying the operator"
-            kustomize build config/default | kubectl apply -f -
-        popd
-
-        echo "Waiting for controller pod to be Ready"
-        # Wait to increase chance that pod is ready
-        # TODO: Should upgrade kubectl to version that supports `kubectl wait pods --all`
-        sleep 60
-    fi 
+    pushd sagemaker-k8s-operator-install-scripts
+        # Since OPERATOR_AWS_SECRET_ACCESS_KEY and OPERATOR_AWS_ACCESS_KEY_ID defined in build spec, we will not create new user
+        ./setup_awscreds
+        path_to_installer=$(pwd)
+    popd
 popd
 
-# Run the integration test file
-cd tests/codebuild/ && ./run_all_sample_test.sh
+echo "RUN INTEGRATION TESTS FOR THE CLUSTER SCOPED OPERATOR DEPLOYMENT"
+# Allow for overriding the installation of the CRDs/controller image from the
+# build scripts if we want to use our own installation
+if [ "${SKIP_INSTALLATION}" == "true" ]; then
+    echo "Skipping installation of CRDs and operator"
+else
+    pushd sagemaker-k8s-operator/sagemaker-k8s-operator-install-scripts
+        echo "Deploying the operator to the default namespace"
+        kustomize build config/default | kubectl apply -f -
+    popd
+    echo "Waiting for controller pod to be Ready"
+    # Wait to increase chance that pod is ready
+    # TODO: Should upgrade kubectl to version that supports `kubectl wait pods --all`
+    sleep 60
+    kubectl get pods --all-namespaces | grep sagemaker
+fi 
+
+echo "Starting Integ Tests in default namespace"
+pushd tests/codebuild
+    ./run_all_sample_test.sh "default"
+popd
 
 echo "Skipping private link test"
 #cd private-link-test && ./run_private_link_integration_test "${cluster_name}" "us-west-2"
+
+echo "RUN INTEGRATION TESTS FOR THE NAMESPACED OPERATOR DEPLOYMENT"
+# HELPER FUNCTIONS
+function generate_iam_role_name {
+    local crd_namespace="$1"
+    local cluster=$(echo ${cluster_name} | cut -d'/' -f2)
+
+    role_name="${cluster}-${crd_namespace}"
+}
+
+function operator_namespace_deploy {
+    local crd_namespace="$1"
+
+    # Goto directory that holds the CRD 
+    pushd sagemaker-k8s-operator/sagemaker-k8s-operator-install-scripts
+        kustomize build config/crd | kubectl apply -f -
+        generate_namespace_operator_installer ${crd_namespace}
+        kubectl apply -f temp_file.yaml
+    popd
+    echo "Waiting for controller pod to be Ready"
+    # Wait to increase chance that pod is ready
+    # TODO: Should upgrade kubectl to version that supports `kubectl wait pods --all`
+    sleep 60
+    echo "Check that the manager pod is running"
+    kubectl get pods --all-namespaces | grep sagemaker
+}
+
+function generate_namespace_operator_installer {
+    local crd_namespace="$1"
+    local aws_account=$(aws sts get-caller-identity --query Account --output text)
+
+    kustomize build config/installers/rolebasedcreds/namespaced > temp_file.yaml
+    sed -i "s/PLACEHOLDER-NAMESPACE/$crd_namespace/g" temp_file.yaml
+    sed -i "s/123456789012/$aws_account/g" temp_file.yaml
+    sed -i "s/DELETE_ME/$role_name/g" temp_file.yaml
+}
+
+# Cleanup 
+echo "Cleanup the default namespace to test namespace deployment"
+cleanup_default_namespace
+
+#Create the IAM Role for the given namespace
+generate_iam_role_name ${crd_namespace}
+cd scripts && ./generate_iam_role.sh ${cluster_name} ${crd_namespace} ${role_name} && cd ..
+
+# Allow for overriding the installation of the CRDs/controller image from the
+# build scripts if we want to use our own installation
+if [ "${SKIP_INSTALLATION}" == "true" ]; then
+    echo "Skipping installation of CRDs and operator"
+else
+    operator_namespace_deploy "${crd_namespace}"        
+fi 
+
+# Run the integration test file
+echo "Starting Integ Tests for namespaced operator deployment"
+pushd tests/codebuild/ 
+    ./run_all_sample_test.sh "${crd_namespace}"
+popd
+

--- a/tests/codebuild/run_integtest.sh
+++ b/tests/codebuild/run_integtest.sh
@@ -28,7 +28,6 @@ function cleanup_default_namespace {
     get_manager_logs
     delete_all_resources "default"
     kustomize build "$path_to_installer/config/default" | kubectl delete -f -
-    set -e
 }
 
 # A function to cleanup resources before exit. If cluster was not launched by the script, only the CRDs, jobs and operator will be deleted.
@@ -59,7 +58,6 @@ function cleanup {
     if [ "${existing_fsx}" == "false" ] && [ "$FSX_ID" != "" ]; then
         aws fsx --region us-west-2 delete-file-system --file-system-id "$FSX_ID"
     fi
-    set -e
 }
 
 # Set the trap to clean up resources
@@ -192,7 +190,10 @@ function generate_namespace_operator_installer {
 
 # Cleanup 
 echo "Cleanup the default namespace to test namespace deployment"
-cleanup_default_namespace
+##cleanup_default_namespace
+
+# If any command fails, exit the script with an error code.
+set -e
 
 #Create the IAM Role for the given namespace
 generate_iam_role_name "${crd_namespace}"

--- a/tests/codebuild/run_integtest.sh
+++ b/tests/codebuild/run_integtest.sh
@@ -93,6 +93,7 @@ if [ "${need_setup_cluster}" == "true" ]; then
 
     # By default eksctl picks random AZ, which time to time leads to capacity issue.
     eksctl create cluster "${cluster_name}" --nodes 2 --node-type=c5.4xlarge --timeout=40m --region "${cluster_region}" --zones us-east-1a,us-east-1b,us-east-1c --auto-kubeconfig --version=1.14 --fargate 
+    eksctl create fargateprofile --namespace "${crd_namespace}" --cluster "${cluster_name}" --name namespace-profile --region "${cluster_region}"
     eksctl create fargateprofile --namespace sagemaker-k8s-operator-system --cluster "${cluster_name}" --name operator-profile --region "${cluster_region}"
 
     echo "Setting kubeconfig"

--- a/tests/codebuild/testfiles/xgboost-mnist-trainingjob-namespaced.yaml
+++ b/tests/codebuild/testfiles/xgboost-mnist-trainingjob-namespaced.yaml
@@ -1,0 +1,55 @@
+apiVersion: sagemaker.aws.amazon.com/v1
+kind: TrainingJob
+metadata:
+  name: xgboost-mnist-namespaced
+spec:
+  hyperParameters:
+    - name: max_depth
+      value: "5"
+    - name: eta
+      value: "0.2"
+    - name: gamma
+      value: "4"
+    - name: min_child_weight
+      value: "6"
+    - name: silent
+      value: "0"
+    - name: objective
+      value: multi:softmax
+    - name: num_class
+      value: "10"
+    - name: num_round
+      value: "10"
+  algorithmSpecification:
+    trainingImage: 433757028032.dkr.ecr.us-west-2.amazonaws.com/xgboost:1
+    trainingInputMode: File
+  roleArn: {ROLE_ARN}
+  region: us-west-2
+  outputDataConfig:
+    s3OutputPath: s3://{DATA_BUCKET}/xgboost/
+  resourceConfig:
+    instanceCount: 1
+    instanceType: ml.m4.xlarge
+    volumeSizeInGB: 5
+  stoppingCondition:
+    maxRuntimeInSeconds: 86400
+  inputDataConfig:
+    - channelName: train
+      dataSource:
+        s3DataSource:
+          s3DataType: S3Prefix
+          s3Uri: s3://{DATA_BUCKET}/train/
+          s3DataDistributionType: FullyReplicated
+      contentType: text/csv
+      compressionType: None
+    - channelName: validation
+      dataSource:
+        s3DataSource:
+          s3DataType: S3Prefix
+          s3Uri: s3://{DATA_BUCKET}/validation/
+          s3DataDistributionType: FullyReplicated
+      contentType: text/csv
+      compressionType: None
+  tags:
+    - key: tagKey
+      value: tagValue


### PR DESCRIPTION
### What does this PR do / how does this improve the operators?
1. Integ Tests for namespace deployment 
2. Automated OIDC IAM role generation for the cluster and given namespace.
3. Some cleanup, but much more possible. 

Todo (in a separate PR):
1. Canaries
2. A better input for the `test-namespace` instead of a hardcoded global variable. 
3. `crd_namespace` is not the most appropriate variable name, change to operator_namespace
4. These are simple tests for namespace deployment, should add some more feature tests. Opinions?
5. updated integ test README.

### Which issue(s) does this PR fix?

Fixes #

### Special notes for the reviewer:

### Does this PR require changes to documentation?

### All Submissions:

* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you written or refactored unit tests to cover the change?
* [ ] Have you ran all unit tests and ensured they are passing?
* [ ] Have you manually tested each feature that is being added/modified?
* [ ] Have you ensured you have not introduced linting errors?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.