### PR TITLE
Integration Test for HostingDeployment Autoscaling

### DIFF
--- a/tests/codebuild/common.sh
+++ b/tests/codebuild/common.sh
@@ -63,6 +63,7 @@ function delete_all_resources()
   kubectl delete -n "$crd_namespace" batchtransformjob --all
   kubectl delete -n "$crd_namespace" hostingdeployment --all 
   kubectl delete -n "$crd_namespace" model --all 
+  kubectl delete -n "$crd_namespace" hostingdeploymentautoscalingjobs --all 
 }
 
 # A helper function to generate an IAM Role name for the current cluster and specified namespace

--- a/tests/codebuild/create_tests.sh
+++ b/tests/codebuild/create_tests.sh
@@ -88,7 +88,7 @@ function verify_integration_tests
 }
 
 
-# Replaces the names of the endpoint generated in the previous test into the hap spec file. 
+# Replaces the names of the endpoint generated in the previous test into the hap spec file and runs the test. 
 # Parameter:
 #    $1: Target namespace
 #    $2: K8s Name of the hostingdeployment to apply autoscaling 
@@ -116,8 +116,6 @@ function run_hap_test()
   sed -i "s/PLACEHOLDER-ENDPOINT-1/$endpoint_name_1/g" "$file_name"
   sed -i "s/PLACEHOLDER-ENDPOINT-2/$endpoint_name_2/g" "$file_name"
   run_test "$target_namespace" "$file_name"
-
-  kubectl describe hostingdeploymentautoscalingjob 
 }
 
 # This function verifies that the hostingdeploymentautoscalingjob is applied as expected, and checks using awscli

--- a/tests/codebuild/testfiles/xgboost-hosting-deployment.yaml
+++ b/tests/codebuild/testfiles/xgboost-hosting-deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: sagemaker.aws.amazon.com/v1
 kind: HostingDeployment
 metadata:
-  name: hosting
+  name: xgboost-hosting
 spec:
   region: us-west-2
   productionVariants:

--- a/tests/codebuild/testfiles/xgboost-hostingautoscaling-custom.yaml
+++ b/tests/codebuild/testfiles/xgboost-hostingautoscaling-custom.yaml
@@ -1,0 +1,25 @@
+apiVersion: sagemaker.aws.amazon.com/v1
+kind: HostingDeploymentAutoscalingJob
+metadata:
+  name: ep-autoscaling-predefined-custom
+spec:
+    resourceId:
+      - endpointName: PLACEHOLDER-ENDPOINT-1
+        variantName: AllTraffic
+    region: us-east-2
+    policyName: custom-scaling-policy
+    policyType: TargetTrackingScaling
+    minCapacity: 1
+    maxCapacity: 1
+    targetTrackingScalingPolicyConfiguration:
+        targetValue: 60.0 
+        scaleInCooldown: 700 
+        scaleOutCooldown: 300
+        customizedMetricSpecification: 
+          metricName: CPUUtilization 
+          namespace: /aws/sagemaker/Endpoints 
+          dimensions:  
+             - name: xgboost-2020-06-01-20-39-37-30
+               value:  AllTraffic
+          statistic: Average 
+          unit: Percent

--- a/tests/codebuild/testfiles/xgboost-hostingautoscaling.yaml
+++ b/tests/codebuild/testfiles/xgboost-hostingautoscaling.yaml
@@ -1,0 +1,21 @@
+apiVersion: sagemaker.aws.amazon.com/v1
+kind: HostingDeploymentAutoscalingJob
+metadata:
+  name: hap-predefined
+spec:
+    resourceId:
+      - endpointName: PLACEHOLDER-ENDPOINT-1
+        variantName: AllTraffic
+      - endpointName: PLACEHOLDER-ENDPOINT-2
+        variantName: AllTraffic
+    region: us-west-2
+    policyName: SageMakerEndpointInvocationScalingPolicy
+    policyType: TargetTrackingScaling
+    minCapacity: 1
+    maxCapacity: 2
+    targetTrackingScalingPolicyConfiguration:
+        targetValue: 70.0 
+        predefinedMetricSpecification: 
+            predefinedMetricType: SageMakerVariantInvocationsPerInstance 
+        scaleInCooldown: 700 
+        scaleOutCooldown: 300


### PR DESCRIPTION
### What does this PR do / how does this improve the operators?
Added an integration Test for the HostingDeploymentAutoscalingJob - 
1. In order to test multiple endpoint/variant pairs I create a second hostingdeployment job
2. I wait for both to complete and then capture the sagemaker name of the endpoint
3. I added an additional check where it uses the awscli to make sure a scalingPolicy is applied

### Special notes for the reviewer:
 - Coming up - a custom policy test
 - The CRD name to be changed after these PRs are merged

### Does this PR require changes to documentation?
No

### All Submissions:

* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you written or refactored unit tests to cover the change?
* [ ] Have you ran all unit tests and ensured they are passing?
* [ ] Have you manually tested each feature that is being added/modified?
* [ ] Have you ensured you have not introduced linting errors?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.