### PR TITLE
Use modify-base-kustomize-us instead of set-image

### DIFF
--- a/codebuild/scripts/package_operators.sh
+++ b/codebuild/scripts/package_operators.sh
@@ -79,7 +79,7 @@ function package_operator()
 
   # Build, push and update the CRD with controller image and current git SHA, create the tarball and extract it to pack
   local ecr_image=${account_id}.dkr.ecr.${account_region}.amazonaws.com/${image_repository}
-  make set-image IMG=${ecr_image}:$CODEBUILD_RESOLVED_SOURCE_VERSION
+  make modify-base-kustomize-us IMG=${ecr_image}:$CODEBUILD_RESOLVED_SOURCE_VERSION
   make build-release-tarball
   pushd bin
     tar -xf sagemaker-k8s-operator-install-scripts.tar.gz


### PR DESCRIPTION
Recently set-image was renamed to modify-base-kustomize-us (which does bit more than just setting the image) which caused the [codebuild scrip](https://github.com/aws/amazon-sagemaker-operator-for-k8s/blob/b61f47ecfd334b1743070f25f38ea90189c164ba/codebuild/scripts/package_operators.sh#L82) to fail

Made the change to use modify-base-kustomize-us 

Tested the changes by running the codebuild against this PR