### PR TITLE
fix: create installer should happen after generating CRDs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,9 +11,14 @@ information to effectively respond to your bug report or contribution.
 This guide assumes that you have a k8s cluster setup and can access it via kubectl.
 Make sure your k8s cluster server version is >=1.12 and client version >=1.15
 
-To register the CRD in the cluster:
+To register the CRD in the cluster and create installers:
 ```
-make install 
+make generate_and_install
+```
+
+If you want to only register the CRD in the cluster:
+```
+make install
 ```
 
 To run the controller, run the following command. The controller runs in an infinite loop so open another terminal to create CRDs.

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,10 @@ run: lint generate fmt vet
 install: manifests
 	kubectl apply -f config/crd/bases
 
+# Generate the CRDs, RBAC etc. install the CRDs onto your cluster and create installers to be keep in sync with CRDs
+# Recommended to use this as opposed to just install if you intend to check-in code
+generate_and_install: install create-installers
+
 # Build a tarball containing everything needed to install the operator onto a cluster.
 # This also removes the awscreds.env file before creating the tarball to make sure that credentials are
 # not included in the release.

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ undeploy: manifests
 
 # Generate manifests e.g. CRD, RBAC etc.
 # Requires golang development setup for controller-gen.
-manifests: controller-gen create-installers
+manifests: controller-gen
 	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 
 # Run go fmt against code


### PR DESCRIPTION
### What does this PR do / how does this improve the operators?
bug fix in generating CRD

### Does this PR require changes to documentation?
No

### Testing:
Make install and manifests work fine and crd get installed on cluster as expected.
Synced up with @RedbackThomson to make sure other make targets are not affected by this change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.