### PR TITLE
Fix HAP integration test

### DIFF
--- a/tests/codebuild/testfiles/xgboost-hosting-deployment.yaml
+++ b/tests/codebuild/testfiles/xgboost-hosting-deployment.yaml
@@ -12,7 +12,7 @@ spec:
       initialVariantWeight: 1
   models:
     - name: xgboost-model
-      executionRoleArn: {ROLE_ARN}
+      executionRoleArn: "{ROLE_ARN}"
       containers:
         - containerHostname: xgboost
           modelDataUrl: s3://{DATA_BUCKET}/inference/xgboost-mnist/model.tar.gz


### PR DESCRIPTION
Error Message : `[FAILED] HostingDeployment test-namespace:xgboost-hosting job does not exist`

Namespace scoped test was failing after running cluster scoped tests due to replacement of placeholder variables with sed.