### PR TITLE
Update kustomization.yaml

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -9,7 +9,7 @@ resources:
 - bases/sagemaker.aws.amazon.com_processingjobs.yaml
 # +kubebuilder:scaffold:crdkustomizeresource
 
-patches:
+patchesStrategicMerge:
 - patches/role-arn-validation-pattern.yaml
 # [WEBHOOK] patches here are for enabling the conversion webhook for each CRD
 #- patches/webhook_in_trainingjobs.yaml


### PR DESCRIPTION
### What does this PR do / how does this improve the operators?

Updates the kustomize manifest to use `patchesStrategicMerge` instead of `patches`. The current instance (using `patches`) causes some versions of kustomize to fail on build. [According to this GH issue](https://github.com/kubernetes-sigs/kustomize/issues/1373) `patchesStrategicMerge` is the preferred syntax in this context.

### Which issue(s) does this PR fix?

Fixes #
N/A

### Special notes for the reviewer:

### Does this PR require changes to documentation?

### All Submissions:

* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you written or refactored unit tests to cover the change?
* [ ] Have you ran all unit tests and ensured they are passing?
* [ ] Have you manually tested each feature that is being added/modified?
* [ ] Have you ensured you have not introduced linting errors?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.