### PR TITLE
Fix "Containers" parameter in Model operator

### DIFF
--- a/controllers/model/model_controller.go
+++ b/controllers/model/model_controller.go
@@ -33,6 +33,7 @@ import (
 
 	modelv1 "github.com/aws/amazon-sagemaker-operator-for-k8s/api/v1/model"
 	. "github.com/aws/amazon-sagemaker-operator-for-k8s/controllers"
+	"github.com/aws/amazon-sagemaker-operator-for-k8s/controllers/controllertest"
 	"github.com/aws/amazon-sagemaker-operator-for-k8s/controllers/sdkutil"
 	"github.com/aws/amazon-sagemaker-operator-for-k8s/controllers/sdkutil/clientwrapper"
 )
@@ -210,12 +211,12 @@ func (r *ModelReconciler) initializeContext(ctx *reconcileRequestContext) error 
 	ctx.SageMakerClient = clientwrapper.NewSageMakerClientWrapper(r.createSageMakerClient(awsConfig))
 	ctx.Log.Info("Loaded AWS config")
 
-	if ctx.Model.Spec.PrimaryContainer.Mode == nil {
-		ctx.Model.Spec.PrimaryContainer.Mode = aws.String(DefaultContainerDefinitionMode)
+	if ctx.Model.Spec.PrimaryContainer != nil && ctx.Model.Spec.PrimaryContainer.Mode == nil {
+		ctx.Model.Spec.PrimaryContainer.Mode = controllertest.ToStringPtr(DefaultContainerDefinitionMode)
 	}
 	for _, container := range ctx.Model.Spec.Containers {
 		if container.Mode == nil {
-			container.Mode = aws.String(DefaultContainerDefinitionMode)
+			container.Mode = controllertest.ToStringPtr(DefaultContainerDefinitionMode)
 		}
 	}
 

--- a/controllers/sdkutil/spec_sdk_converters.go
+++ b/controllers/sdkutil/spec_sdk_converters.go
@@ -410,7 +410,7 @@ func CreateModelSpecFromDescription(description *sagemaker.DescribeModelOutput) 
 
 	if description.Containers != nil {
 		for i, _ := range description.Containers {
-			if _, err := obj.SetP(transformedContainersEnvironment[i], "Containers/"+strconv.Itoa(i)+"/.Environment"); err != nil {
+			if _, err := obj.SetP(transformedContainersEnvironment[i], "Containers."+strconv.Itoa(i)+".Environment"); err != nil {
 				return nil, err
 			}
 		}


### PR DESCRIPTION
Fixes following bugs 
1] Reconciliation failure of Model when `Containers` is specified
2] Model creation failure when `PrimaryContainer` is not specified 

Tested it manually 
Cannot modify existing integ test to include this as `Containers` and `PrimaryContainer` are mutually exclusive.
Need to write new integ test.