### PR TITLE
fix: flaky test and duplicates

### DIFF
--- a/tests/codebuild/create_tests.sh
+++ b/tests/codebuild/create_tests.sh
@@ -25,7 +25,6 @@ function run_canary_tests
   run_test "${crd_namespace}" testfiles/xgboost-mnist-batchtransform.yaml 
   run_test "${crd_namespace}" testfiles/xgboost-hosting-deployment.yaml
   run_hap_test "${crd_namespace}" named-xgboost-hosting testfiles/xgboost-hostingautoscaling.yaml testfiles/xgboost-hostingautoscaling-custom.yaml
-  run_test "${crd_namespace}" testfiles/xgboost-mnist-trainingjob-debugger.yaml
 }
 
 # Applies each of the resources needed for the canary tests.
@@ -91,7 +90,6 @@ function verify_canary_tests
   verify_test "${crd_namespace}" HostingAutoscalingPolicy hap-predefined 5m Created
   verify_test "${crd_namespace}" HostingAutoscalingPolicy hap-custom-metric 5m Created
   # verify_hap_test "3"
-  verify_test "${crd_namespace}" TrainingJob xgboost-mnist-debugger 20m Completed
 }
 
 # Verifies that all resources were created and are running/completed for the canary tests.

--- a/tests/codebuild/delete_tests.sh
+++ b/tests/codebuild/delete_tests.sh
@@ -12,7 +12,7 @@ function run_delete_canary_tests
   set -x
   local crd_namespace="$1"
   echo "Running delete canary tests"
-  verify_delete "${crd_namespace}" TrainingJob testfiles/xgboost-mnist-trainingjob.yaml
+  verify_delete "${crd_namespace}" TrainingJob testfiles/xgboost-mnist-trainingjob-debugger.yaml
   verify_delete "${crd_namespace}" ProcessingJob testfiles/kmeans-mnist-processingjob.yaml
   verify_delete "${crd_namespace}" HyperparameterTuningJob testfiles/xgboost-mnist-hpo.yaml
 
@@ -142,7 +142,8 @@ function verify_sm_resource_stopping_else_fail()
   esac
   
   job_status="$(aws sagemaker "describe-${sageMakerResourceType}" "--${sageMakerResourceType}-name" "${job_name}" --region us-west-2 | jq -r "${jobStatusPath}")"
-  if [ "${job_status}" != "Stopping" ] && [ "${job_status}" != "Stopped" ]; then
+  # Job can go from Stopping to completed State if job is completing already like uploading model
+  if [ "${job_status}" != "Stopping" ] && [ "${job_status}" != "Stopped" ] && ["${job_status}" != "Completed"]; then
     echo "[FAILED] AWS SageMaker resource \"${job_name}\" did not stop (status \"${job_status}\")" 
     exit 1
   else


### PR DESCRIPTION
### What does this PR do / how does this improve the operators?
- Delete tests need longer jobs coz jobs are getting completed before tests stop them once in a while. Need to investigate more but replaced the training job in the meantime and increased the time for processing script by 5 mins
  - Added a Completed check for the delete jobs because it's possible for jobs to go from `STOPPING` to `COMPLETE` state if it's about to complete
- Debugger test is already part of integration tests([run](https://github.com/aws/amazon-sagemaker-operator-for-k8s/blob/master/tests/codebuild/create_tests.sh#L74), [verify](https://github.com/aws/amazon-sagemaker-operator-for-k8s/blob/master/tests/codebuild/create_tests.sh#L125-L127)), removed the duplicate from canary test

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you written or refactored unit tests to cover the change?
* [x] Have you ran all unit tests and ensured they are passing?
* [x] Have you manually tested each feature that is being added/modified?
* [x] Have you ensured you have not introduced linting errors?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.