### PR TITLE
fix: hap test uses named resource causes race condition for canaries

### DIFF
--- a/tests/codebuild/create_tests.sh
+++ b/tests/codebuild/create_tests.sh
@@ -24,7 +24,6 @@ function run_canary_tests
   yq w -i testfiles/xgboost-mnist-batchtransform.yaml "spec.modelName" "$(get_sagemaker_model_from_k8s_model "${crd_namespace}" xgboost-model)"
   run_test "${crd_namespace}" testfiles/xgboost-mnist-batchtransform.yaml 
   run_test "${crd_namespace}" testfiles/xgboost-hosting-deployment.yaml
-  run_hap_test "${crd_namespace}" named-xgboost-hosting testfiles/xgboost-hostingautoscaling.yaml testfiles/xgboost-hostingautoscaling-custom.yaml
 }
 
 # Applies each of the resources needed for the canary tests.
@@ -72,6 +71,7 @@ function run_integration_tests
   run_test "${crd_namespace}" testfiles/xgboost-mnist-hpo-custom-endpoint.yaml
   run_test "${crd_namespace}" testfiles/xgboost-mnist-trainingjob-debugger.yaml
   run_test "${crd_namespace}" testfiles/xgboost-hosting-deployment-multi-container.yaml
+  run_hap_test "${crd_namespace}" named-xgboost-hosting testfiles/xgboost-hostingautoscaling.yaml testfiles/xgboost-hostingautoscaling-custom.yaml
   run_test "${crd_namespace}" testfiles/hd-retain-varient-properties.yaml
 }
 
@@ -87,9 +87,6 @@ function verify_canary_tests
   verify_test "${crd_namespace}" HyperparameterTuningJob xgboost-mnist-hpo 20m Completed
   verify_test "${crd_namespace}" BatchTransformJob xgboost-batch 20m Completed 
   verify_test "${crd_namespace}" HostingDeployment xgboost-hosting 90m InService
-  verify_test "${crd_namespace}" HostingAutoscalingPolicy hap-predefined 5m Created
-  verify_test "${crd_namespace}" HostingAutoscalingPolicy hap-custom-metric 5m Created
-  # verify_hap_test "3"
 }
 
 # Verifies that all resources were created and are running/completed for the canary tests.
@@ -123,6 +120,9 @@ function verify_integration_tests
   verify_test "${crd_namespace}" TrainingJob xgboost-mnist-debugger 20m Completed
   # Verify that debug job has status
   verify_debug_test "${crd_namespace}" TrainingJob xgboost-mnist-debugger 20m NoIssuesFound
+  verify_test "${crd_namespace}" HostingAutoscalingPolicy hap-predefined 5m Created
+  verify_test "${crd_namespace}" HostingAutoscalingPolicy hap-custom-metric 5m Created
+  # verify_hap_test "3"
   verify_retain_varient_properties "${crd_namespace}" testfiles/hd-retain-varient-properties.yaml
 }
 

--- a/tests/codebuild/create_tests.sh
+++ b/tests/codebuild/create_tests.sh
@@ -25,7 +25,6 @@ function run_canary_tests
   run_test "${crd_namespace}" testfiles/xgboost-mnist-batchtransform.yaml 
   run_test "${crd_namespace}" testfiles/xgboost-hosting-deployment.yaml
   run_hap_test "${crd_namespace}" named-xgboost-hosting testfiles/xgboost-hostingautoscaling.yaml testfiles/xgboost-hostingautoscaling-custom.yaml
-  run_test "${crd_namespace}" testfiles/xgboost-mnist-trainingjob-debugger.yaml
 }
 
 # Applies each of the resources needed for the canary tests.
@@ -91,7 +90,6 @@ function verify_canary_tests
   verify_test "${crd_namespace}" HostingAutoscalingPolicy hap-predefined 5m Created
   verify_test "${crd_namespace}" HostingAutoscalingPolicy hap-custom-metric 5m Created
   # verify_hap_test "3"
-  verify_test "${crd_namespace}" TrainingJob xgboost-mnist-debugger 20m Completed
 }
 
 # Verifies that all resources were created and are running/completed for the canary tests.

--- a/tests/codebuild/delete_tests.sh
+++ b/tests/codebuild/delete_tests.sh
@@ -12,7 +12,7 @@ function run_delete_canary_tests
   set -x
   local crd_namespace="$1"
   echo "Running delete canary tests"
-  verify_delete "${crd_namespace}" TrainingJob testfiles/xgboost-mnist-trainingjob.yaml
+  verify_delete "${crd_namespace}" TrainingJob testfiles/xgboost-mnist-trainingjob-debugger.yaml
   verify_delete "${crd_namespace}" ProcessingJob testfiles/kmeans-mnist-processingjob.yaml
   verify_delete "${crd_namespace}" HyperparameterTuningJob testfiles/xgboost-mnist-hpo.yaml
 
@@ -142,7 +142,8 @@ function verify_sm_resource_stopping_else_fail()
   esac
   
   job_status="$(aws sagemaker "describe-${sageMakerResourceType}" "--${sageMakerResourceType}-name" "${job_name}" --region us-west-2 | jq -r "${jobStatusPath}")"
-  if [ "${job_status}" != "Stopping" ] && [ "${job_status}" != "Stopped" ]; then
+  # Job can go from Stopping to completed State if job is completing already like uploading model
+  if [ "${job_status}" != "Stopping" ] && [ "${job_status}" != "Stopped" ] && ["${job_status}" != "Completed"]; then
     echo "[FAILED] AWS SageMaker resource \"${job_name}\" did not stop (status \"${job_status}\")" 
     exit 1
   else

--- a/tests/codebuild/update_tests.sh
+++ b/tests/codebuild/update_tests.sh
@@ -9,12 +9,6 @@ source inject_tests.sh
 function run_update_canary_tests
 {
   local crd_namespace="$1"
-
-  echo "Injecting variables into tests"
-  inject_all_variables
-
-  echo "Starting Update Tests"
-  update_hap_test "${crd_namespace}" named-xgboost-hosting testfiles/xgboost-hostingautoscaling.yaml
 }
 
 # Parameter:
@@ -24,6 +18,12 @@ function run_update_integration_tests
   echo "Running update integration tests"
   local crd_namespace="$1"
   run_update_canary_tests "${crd_namespace}"
+
+  echo "Injecting variables into tests"
+  inject_all_variables
+
+  echo "Starting Update Tests"
+  update_hap_test "${crd_namespace}" named-xgboost-hosting testfiles/xgboost-hostingautoscaling.yaml
 }
 
 # Verifies that all resources were created and are running/completed for the canary tests.
@@ -33,10 +33,6 @@ function verify_update_canary_tests
 {
   local crd_namespace="$1"
   echo "Verifying update tests"
-
-  # At this point there are two variants in total(1 predefined and 1 custom) that have HAP applied. 
-  verify_test "${crd_namespace}" HostingAutoscalingPolicy hap-predefined 5m Created
-  # verify_hap_test "2"
 }
 
 
@@ -49,6 +45,9 @@ function verify_update_integration_tests
   local crd_namespace="$1"
   verify_update_canary_tests
 
+  # At this point there are two variants in total(1 predefined and 1 custom) that have HAP applied. 
+  verify_test "${crd_namespace}" HostingAutoscalingPolicy hap-predefined 5m Created
+  # verify_hap_test "2"
 }
 
 # Updates the ResourceID List and the MaxCapacity in the spec to check for updates 


### PR DESCRIPTION
### What does this PR do / how does this improve the operators?
HAP test use a named endpoint causing race condition if more than one test suite is running in parallel. Hence, moving it to integration tests
To enable back in canaries test will need to be modified

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you written or refactored unit tests to cover the change?
* [x] Have you ran all unit tests and ensured they are passing?
* [x] Have you manually tested each feature that is being added/modified?
* [x] Have you ensured you have not introduced linting errors?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.