### PR TITLE
[WIP] HAP Integ Test - add random string to endpoint name to fix race condition

### DIFF
--- a/tests/codebuild/update_tests.sh
+++ b/tests/codebuild/update_tests.sh
@@ -9,12 +9,6 @@ source inject_tests.sh
 function run_update_canary_tests
 {
   local crd_namespace="$1"
-
-  echo "Injecting variables into tests"
-  inject_all_variables
-
-  echo "Starting Update Tests"
-  update_hap_test "${crd_namespace}" named-xgboost-hosting testfiles/xgboost-hostingautoscaling.yaml
 }
 
 # Parameter:
@@ -24,6 +18,12 @@ function run_update_integration_tests
   echo "Running update integration tests"
   local crd_namespace="$1"
   run_update_canary_tests "${crd_namespace}"
+
+  echo "Injecting variables into tests"
+  inject_all_variables
+
+  echo "Starting Update Tests"
+  update_hap_test "${crd_namespace}" named-xgboost-hosting testfiles/xgboost-hostingautoscaling.yaml
 }
 
 # Verifies that all resources were created and are running/completed for the canary tests.
@@ -33,10 +33,6 @@ function verify_update_canary_tests
 {
   local crd_namespace="$1"
   echo "Verifying update tests"
-
-  # At this point there are two variants in total(1 predefined and 1 custom) that have HAP applied. 
-  verify_test "${crd_namespace}" HostingAutoscalingPolicy hap-predefined 5m Created
-  # verify_hap_test "2"
 }
 
 
@@ -49,6 +45,9 @@ function verify_update_integration_tests
   local crd_namespace="$1"
   verify_update_canary_tests
 
+  # At this point there are two variants in total(1 predefined and 1 custom) that have HAP applied. 
+  verify_test "${crd_namespace}" HostingAutoscalingPolicy hap-predefined 5m Created
+  # verify_hap_test "2"
 }
 
 # Updates the ResourceID List and the MaxCapacity in the spec to check for updates 
@@ -58,8 +57,9 @@ function verify_update_integration_tests
 #    $3: Filename of the hap test to update
 function update_hap_test()
 {
+  local random_string=$RANDOM
   local target_namespace="$1"
-  local hosting_deployment_1="$2"
+  local hosting_deployment_1="${2}-${random_string}"
   local file_name="$3"
   local hostingdeployment_type="hostingdeployment"
   local updated_filename="${file_name}-updated-${target_namespace}"


### PR DESCRIPTION
### What does this PR do / how does this improve the operators?
1. This PR reverts PR #167 
2. adds a random string to the endpoint name to fix the race condition (both create and update test)

### [WIP] Testing
1. Reproduced the error by reverting PR #167 and triggering two integration test runs to see that one failed. 
2. Used the same steps to then check that the fix actually works and the race condition is not reproduced. 

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you written or refactored unit tests to cover the change?
* [x] Have you ran all unit tests and ensured they are passing?
* [x] Have you manually tested each feature that is being added/modified?
* [x] Have you ensured you have not introduced linting errors?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.