### PR TITLE
Rename compressionType to s3CompressionType

### DIFF
--- a/api/v1/common/sagemaker_api.go
+++ b/api/v1/common/sagemaker_api.go
@@ -80,7 +80,7 @@ type ProcessingInput struct {
 type ProcessingS3Input struct {
 	LocalPath LocalPath `json:"localPath"`
 
-	CompressionType CompressionType `json:"compressionType,omitempty"`
+	CompressionType CompressionType `json:"s3CompressionType,omitempty"`
 
 	// +kubebuilder:validation:Enum=FullyReplicated;ShardedByS3Key
 	S3DataDistributionType S3DataDistributionType `json:"s3DataDistributionType,omitempty"`

--- a/config/crd/bases/sagemaker.aws.amazon.com_processingjobs.yaml
+++ b/config/crd/bases/sagemaker.aws.amazon.com_processingjobs.yaml
@@ -99,13 +99,13 @@ spec:
                     type: string
                   s3Input:
                     properties:
-                      compressionType:
+                      localPath:
+                        maxLength: 256
+                        type: string
+                      s3CompressionType:
                         enum:
                         - None
                         - Gzip
-                        type: string
-                      localPath:
-                        maxLength: 256
                         type: string
                       s3DataDistributionType:
                         allOf:

--- a/hack/charts/installer/rolebased/templates/crds.yaml
+++ b/hack/charts/installer/rolebased/templates/crds.yaml
@@ -1629,13 +1629,13 @@ spec:
                     type: string
                   s3Input:
                     properties:
-                      compressionType:
+                      localPath:
+                        maxLength: 256
+                        type: string
+                      s3CompressionType:
                         enum:
                         - None
                         - Gzip
-                        type: string
-                      localPath:
-                        maxLength: 256
                         type: string
                       s3DataDistributionType:
                         allOf:

--- a/hack/charts/namespaced/crd_chart/templates/crds.yaml
+++ b/hack/charts/namespaced/crd_chart/templates/crds.yaml
@@ -1629,13 +1629,13 @@ spec:
                     type: string
                   s3Input:
                     properties:
-                      compressionType:
+                      localPath:
+                        maxLength: 256
+                        type: string
+                      s3CompressionType:
                         enum:
                         - None
                         - Gzip
-                        type: string
-                      localPath:
-                        maxLength: 256
                         type: string
                       s3DataDistributionType:
                         allOf:

--- a/release/rolebased/china/installer_china.yaml
+++ b/release/rolebased/china/installer_china.yaml
@@ -1636,13 +1636,13 @@ spec:
                     type: string
                   s3Input:
                     properties:
-                      compressionType:
+                      localPath:
+                        maxLength: 256
+                        type: string
+                      s3CompressionType:
                         enum:
                         - None
                         - Gzip
-                        type: string
-                      localPath:
-                        maxLength: 256
                         type: string
                       s3DataDistributionType:
                         allOf:

--- a/release/rolebased/installer.yaml
+++ b/release/rolebased/installer.yaml
@@ -1636,13 +1636,13 @@ spec:
                     type: string
                   s3Input:
                     properties:
-                      compressionType:
+                      localPath:
+                        maxLength: 256
+                        type: string
+                      s3CompressionType:
                         enum:
                         - None
                         - Gzip
-                        type: string
-                      localPath:
-                        maxLength: 256
                         type: string
                       s3DataDistributionType:
                         allOf:

--- a/release/rolebased/namespaced/china/crd.yaml
+++ b/release/rolebased/namespaced/china/crd.yaml
@@ -1629,13 +1629,13 @@ spec:
                     type: string
                   s3Input:
                     properties:
-                      compressionType:
+                      localPath:
+                        maxLength: 256
+                        type: string
+                      s3CompressionType:
                         enum:
                         - None
                         - Gzip
-                        type: string
-                      localPath:
-                        maxLength: 256
                         type: string
                       s3DataDistributionType:
                         allOf:

--- a/release/rolebased/namespaced/crd.yaml
+++ b/release/rolebased/namespaced/crd.yaml
@@ -1629,13 +1629,13 @@ spec:
                     type: string
                   s3Input:
                     properties:
-                      compressionType:
+                      localPath:
+                        maxLength: 256
+                        type: string
+                      s3CompressionType:
                         enum:
                         - None
                         - Gzip
-                        type: string
-                      localPath:
-                        maxLength: 256
                         type: string
                       s3DataDistributionType:
                         allOf:


### PR DESCRIPTION
### What does this PR do / how does this improve the operators?
The `ProcessingJob` CRD was referencing `compressionType` whereas the SDK requires it be named `s3CompressionTYpe`

### Which issue(s) does this PR fix?

Fixes # N/A

### Special notes for the reviewer:

### Does this PR require changes to documentation?

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you written or refactored unit tests to cover the change?
* [x] Have you ran all unit tests and ensured they are passing?
* [x] Have you manually tested each feature that is being added/modified?
* [x] Have you ensured you have not introduced linting errors?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.