### PR TITLE
enable ssm on worker nodes

### DIFF
--- a/tests/codebuild/run_canarytest.sh
+++ b/tests/codebuild/run_canarytest.sh
@@ -66,7 +66,7 @@ then
    [ "${CLUSTER_PUBLIC_SUBNETS}" != "" ] && eksctl_args+=( --vpc-public-subnets="${CLUSTER_PUBLIC_SUBNETS}" )
    [ "${CLUSTER_PRIVATE_SUBNETS}" != "" ] && eksctl_args+=( --vpc-private-subnets="${CLUSTER_PRIVATE_SUBNETS}" )
 
-   eksctl create cluster "${cluster_name}" "${eksctl_args[@]}"
+   eksctl create cluster "${cluster_name}" "${eksctl_args[@]}" --enable-ssm
 
    echo "Setting kubeconfig"
    export KUBECONFIG="/root/.kube/eksctl/clusters/${cluster_name}"

--- a/tests/codebuild/run_canarytest_china.sh
+++ b/tests/codebuild/run_canarytest_china.sh
@@ -61,7 +61,7 @@ function create_eks_cluster() {
   [ ! -z "${USE_EXISTING_SUBNET}" ] && eksctl_args+=( --vpc-public-subnets="${EKS_PUBLIC_SUBNET_1},${EKS_PUBLIC_SUBNET_2}" )
   [ ! -z "${USE_EXISTING_SUBNET}" ] && eksctl_args+=( --vpc-private-subnets="${EKS_PRIVATE_SUBNET_1},${EKS_PRIVATE_SUBNET_2}" )
 
-  eksctl create cluster "$CLUSTER_NAME" "${eksctl_args[@]}"
+  eksctl create cluster "$CLUSTER_NAME" "${eksctl_args[@]}" --enable-ssm
 }
 
 function install_k8s_operators() {


### PR DESCRIPTION
### What does this PR do / how does this improve the operators?
enables ssm on worker nodes so they can be patched
option exists in latest eksctl - https://eksctl.io/introduction/#ssh-access
BuildCanaryStep in pipeline installs latest eksctl - [dockerfile](https://github.com/aws/amazon-sagemaker-operator-for-k8s/blob/master/tests/images/Dockerfile.canary#L22), [script](https://github.com/aws/amazon-sagemaker-operator-for-k8s/blob/master/tests/build_canary.sh#L3), [codebuild](https://github.com/aws/amazon-sagemaker-operator-for-k8s/blob/master/codebuild/build_canary.yaml#L10)

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you written or refactored unit tests to cover the change?
* [x] Have you ran all unit tests and ensured they are passing?
* [x] Have you manually tested each feature that is being added/modified?
* [x] Have you ensured you have not introduced linting errors?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.