### PR TITLE
Update all installers to v1.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Image URL to use all building/pushing image targets
-IMG ?= 957583890962.dkr.ecr.us-east-1.amazonaws.com/amazon-sagemaker-operator-for-k8s:v1
-IMG_CHINA ?= 099223943020.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-sagemaker-operator-for-k8s:v1
+IMG ?= 957583890962.dkr.ecr.us-east-1.amazonaws.com/amazon-sagemaker-operator-for-k8s:v1.2
+IMG_CHINA ?= 099223943020.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-sagemaker-operator-for-k8s:v1.2
 
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true"

--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -9,7 +9,7 @@ kind: Kustomization
 images:
 - name: controller
   newName: 957583890962.dkr.ecr.us-east-1.amazonaws.com/amazon-sagemaker-operator-for-k8s
-  newTag: v1
+  newTag: v1.2
 resources:
 - ../manager
 patchesStrategicMerge:

--- a/hack/charts/installer/rolebased/values.yaml
+++ b/hack/charts/installer/rolebased/values.yaml
@@ -2,5 +2,5 @@ roleArn: arn:aws:iam::123456789012:role/DELETE_ME
 
 image:
   repository: 957583890962.dkr.ecr.us-east-1.amazonaws.com/amazon-sagemaker-operator-for-k8s
-  tag: v1
+  tag: v1.2
 

--- a/hack/charts/namespaced/operator_chart/values.yaml
+++ b/hack/charts/namespaced/operator_chart/values.yaml
@@ -2,4 +2,4 @@ roleArn: arn:aws:iam::123456789012:role/DELETE_ME
 
 image:
   repository: 957583890962.dkr.ecr.us-east-1.amazonaws.com/amazon-sagemaker-operator-for-k8s
-  tag: v1
+  tag: v1.2

--- a/release/rolebased/china/installer_china.yaml
+++ b/release/rolebased/china/installer_china.yaml
@@ -2548,7 +2548,7 @@ spec:
         env:
         - name: AWS_DEFAULT_SAGEMAKER_ENDPOINT
           value: ""
-        image: 099223943020.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-sagemaker-operator-for-k8s:v1
+        image: 099223943020.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-sagemaker-operator-for-k8s:v1.2
         imagePullPolicy: Always
         name: manager
         resources:

--- a/release/rolebased/installer.yaml
+++ b/release/rolebased/installer.yaml
@@ -2558,7 +2558,7 @@ spec:
         env:
         - name: AWS_DEFAULT_SAGEMAKER_ENDPOINT
           value: ""
-        image: 957583890962.dkr.ecr.us-east-1.amazonaws.com/amazon-sagemaker-operator-for-k8s:v1
+        image: 957583890962.dkr.ecr.us-east-1.amazonaws.com/amazon-sagemaker-operator-for-k8s:v1.2
         imagePullPolicy: Always
         name: manager
         resources:

--- a/release/rolebased/namespaced/china/operator_china.yaml
+++ b/release/rolebased/namespaced/china/operator_china.yaml
@@ -314,7 +314,7 @@ spec:
         env:
         - name: AWS_DEFAULT_SAGEMAKER_ENDPOINT
           value: ""
-        image: 099223943020.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-sagemaker-operator-for-k8s:v1
+        image: 099223943020.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon-sagemaker-operator-for-k8s:v1.2
         imagePullPolicy: Always
         name: manager
         resources:

--- a/release/rolebased/namespaced/operator.yaml
+++ b/release/rolebased/namespaced/operator.yaml
@@ -314,7 +314,7 @@ spec:
         env:
         - name: AWS_DEFAULT_SAGEMAKER_ENDPOINT
           value: ""
-        image: 957583890962.dkr.ecr.us-east-1.amazonaws.com/amazon-sagemaker-operator-for-k8s:v1
+        image: 957583890962.dkr.ecr.us-east-1.amazonaws.com/amazon-sagemaker-operator-for-k8s:v1.2
         imagePullPolicy: Always
         name: manager
         resources:


### PR DESCRIPTION
Updates all Helm and Kustomize release scripts to referencing the v1.2 tag.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.