### PR TITLE
Remove enable-leader-election as default

### DIFF
--- a/config/base/manager_auth_proxy_patch.yaml
+++ b/config/base/manager_auth_proxy_patch.yaml
@@ -19,6 +19,3 @@ spec:
         ports:
         - containerPort: 8443
           name: https
-      - name: manager
-        args:
-        - "--metrics-addr=127.0.0.1:8080"

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -26,7 +26,7 @@ spec:
       - command:
         - /manager
         args:
-        - --enable-leader-election
+        - --metrics-addr=127.0.0.1:8080 
         image: controller:latest
         imagePullPolicy: Always
         name: manager

--- a/release/rolebased/china/installer_china.yaml
+++ b/release/rolebased/china/installer_china.yaml
@@ -2542,7 +2542,7 @@ spec:
     spec:
       containers:
       - args:
-        - --enable-leader-election
+        - --metrics-addr=127.0.0.1:8080
         command:
         - /manager
         env:

--- a/release/rolebased/namespaced/china/operator_china.yaml
+++ b/release/rolebased/namespaced/china/operator_china.yaml
@@ -307,7 +307,7 @@ spec:
     spec:
       containers:
       - args:
-        - --enable-leader-election
+        - --metrics-addr=127.0.0.1:8080
         - --namespace=PLACEHOLDER-NAMESPACE
         command:
         - /manager


### PR DESCRIPTION
### Which issue(s) does this PR fix?

`ERROR	setup	unable to start manager	{"error": "LeaderElectionID must be configured"}`

For China region `--enable-leader-election` was set by default.

Looks like that feature is broken and further investigation is required.
For now remove that argument from default 

### Testing 

All the files are auto generated and tested locally.

### Note to reviewers

Our `1.1.0` release was with `controller-runtime` version `v0.2.0`
in Aug 2020 we updated the version to 0.6.1 : https://github.com/aws/amazon-sagemaker-operator-for-k8s/pull/129
in Sep 2020 we updated the version to 0.6.2 : https://github.com/aws/amazon-sagemaker-operator-for-k8s/pull/139
Our `1.2.0` release was with `controller-runtime` version `v0.6.2`

I verified that the 1.1.0 image works fine with `--enable-leader-election` in China region

This version update seems to be the root cause and we need to change our main.go function to fix manager creation with new options 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.