### PR TITLE
update helm chart version for 1.2.1 and cluster version

### DIFF
--- a/hack/charts/batch-transform-jobs/Chart.yaml
+++ b/hack/charts/batch-transform-jobs/Chart.yaml
@@ -5,9 +5,9 @@ description: A Helm chart for deploying a SageMaker Batch Transform Job from Kub
 maintainers:
   - name: Gautam Kumar
     email: gauta@amazon.com
-  - name: Cade Daniel
-    email: cdnamz@amazon.com
-  - name: Nicholas Thomson
-    email: nithomso@amazon.com
+  - name: Suraj Kota
+    email: surakota@amazon.com
+  - name: Kartik Kalamadi
+    email: kalamadi@amazon.com
   - name: Meghna Baijal
     email: mbaijal@amazon.com

--- a/hack/charts/hyperparameter-tuning-jobs/Chart.yaml
+++ b/hack/charts/hyperparameter-tuning-jobs/Chart.yaml
@@ -5,9 +5,9 @@ description: A Helm chart for deploying a SageMaker HyperParameter tuning job fr
 maintainers:
   - name: Gautam Kumar
     email: gauta@amazon.com
-  - name: Cade Daniel
-    email: cdnamz@amazon.com
-  - name: Nicholas Thomson
-    email: nithomso@amazon.com
+  - name: Suraj Kota
+    email: surakota@amazon.com
+  - name: Kartik Kalamadi
+    email: kalamadi@amazon.com
   - name: Meghna Baijal
     email: mbaijal@amazon.com

--- a/hack/charts/installer/rolebased/Chart.yaml
+++ b/hack/charts/installer/rolebased/Chart.yaml
@@ -1,15 +1,15 @@
 apiVersion: v1
 name: amazon-sagemaker-operator-for-k8s
 version: 1.0.0
-appVersion: 1.2.0
+appVersion: 1.2.1
 description: A Helm chart for deploying the Amazon SageMaker Operator for Kubernetes using EKS IAM roles for service accounts.
 maintainers:
   - name: Gautam Kumar
     email: gauta@amazon.com
-  - name: Cade Daniel
-    email: cdnamz@amazon.com
-  - name: Nicholas Thomson
-    email: nithomso@amazon.com
+  - name: Suraj Kota
+    email: surakota@amazon.com
+  - name: Kartik Kalamadi
+    email: kalamadi@amazon.com
   - name: Meghna Baijal
     email: mbaijal@amazon.com
 keywords:

--- a/hack/charts/namespaced/crd_chart/Chart.yaml
+++ b/hack/charts/namespaced/crd_chart/Chart.yaml
@@ -1,15 +1,15 @@
 apiVersion: v1
 name: amazon-sagemaker-operator-for-k8s-install-crds
 version: 1.0.0
-appVersion: 1.2.0
+appVersion: 1.2.1
 description: A Helm chart for deploying the Amazon SageMaker Operator CRDs for Kubernetes using EKS IAM roles for service accounts.
 maintainers:
   - name: Gautam Kumar
     email: gauta@amazon.com
-  - name: Cade Daniel
-    email: cdnamz@amazon.com
-  - name: Nicholas Thomson
-    email: nithomso@amazon.com
+  - name: Suraj Kota
+    email: surakota@amazon.com
+  - name: Kartik Kalamadi
+    email: kalamadi@amazon.com
   - name: Meghna Baijal
     email: mbaijal@amazon.com
 keywords:

--- a/hack/charts/namespaced/operator_chart/Chart.yaml
+++ b/hack/charts/namespaced/operator_chart/Chart.yaml
@@ -6,10 +6,10 @@ description: A Helm chart for deploying the Amazon SageMaker Operator to a speci
 maintainers:
   - name: Gautam Kumar
     email: gauta@amazon.com
-  - name: Cade Daniel
-    email: cdnamz@amazon.com
-  - name: Nicholas Thomson
-    email: nithomso@amazon.com
+  - name: Suraj Kota
+    email: surakota@amazon.com
+  - name: Kartik Kalamadi
+    email: kalamadi@amazon.com
   - name: Meghna Baijal
     email: mbaijal@amazon.com
 keywords:

--- a/hack/charts/training-jobs/Chart.yaml
+++ b/hack/charts/training-jobs/Chart.yaml
@@ -3,12 +3,12 @@ name: amazon-sagemaker-trainingjob
 version: 1.0.0
 description: A Helm chart for deploying a SageMaker TrainingJob from Kubernetes.
 maintainers:
-  - name: Cade Daniel
-    email: cdnamz@amazon.com
   - name: Gautam Kumar
     email: gauta@amazon.com
-  - name: Nicholas Thomson
-    email: nithomso@amazon.com
+  - name: Suraj Kota
+    email: surakota@amazon.com
+  - name: Kartik Kalamadi
+    email: kalamadi@amazon.com
   - name: Meghna Baijal
     email: mbaijal@amazon.com
 # dependencies:

--- a/tests/codebuild/run_canarytest.sh
+++ b/tests/codebuild/run_canarytest.sh
@@ -46,7 +46,7 @@ source ./common.sh
 # Build environment `Docker image` has all prerequisite setup and credentials are being passed using AWS system manager
 
 CLUSTER_REGION=${CLUSTER_REGION:-us-east-1}
-CLUSTER_VERSION=${CLUSTER_VERSION:-1.13}
+CLUSTER_VERSION=1.17
 
 # Define the list of optional subnets for the EKS test cluster
 CLUSTER_PUBLIC_SUBNETS=${CLUSTER_PUBLIC_SUBNETS:-}

--- a/tests/codebuild/run_integtest.sh
+++ b/tests/codebuild/run_integtest.sh
@@ -74,7 +74,7 @@ if [ "${need_setup_cluster}" == "true" ]; then
     readonly cluster_region="us-east-1"
 
     # By default eksctl picks random AZ, which time to time leads to capacity issue.
-    eksctl create cluster "${cluster_name}" --timeout=40m --region "${cluster_region}" --zones us-east-1a,us-east-1b,us-east-1c --auto-kubeconfig --version=1.15 --fargate
+    eksctl create cluster "${cluster_name}" --timeout=40m --region "${cluster_region}" --zones us-east-1a,us-east-1b,us-east-1c --auto-kubeconfig --version=1.17 --fargate
     eksctl create fargateprofile --namespace "${crd_namespace}" --cluster "${cluster_name}" --name namespace-profile --region "${cluster_region}"
     eksctl create fargateprofile --namespace "${default_operator_namespace}" --cluster "${cluster_name}" --name operator-profile --region "${cluster_region}"
 


### PR DESCRIPTION
Release version update for 1.2.1

Cluster version update:
- [eks version 1.15 is deprecated.](https://aws.amazon.com/premiumsupport/knowledge-center/eks-end-of-support-kubernetes-115/)
- removing the environment variable in tests/codebuild/run_canarytest.sh so it can be changed in single for for CI and canary

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.