### PR TITLE
update missing helm chart version

### DIFF
--- a/hack/charts/namespaced/operator_chart/Chart.yaml
+++ b/hack/charts/namespaced/operator_chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: amazon-sagemaker-operator-for-k8s-install-operator
 version: 1.0.0
-appVersion: 1.2.0
+appVersion: 1.2.1
 description: A Helm chart for deploying the Amazon SageMaker Operator to a specified namespace for Kubernetes using EKS IAM roles for service accounts.
 maintainers:
   - name: Gautam Kumar


### PR DESCRIPTION
fixes the missing update in https://github.com/aws/amazon-sagemaker-operator-for-k8s/pull/181

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.