### PR TITLE
get_manager_logs before deleting resources 

### DIFF
--- a/tests/codebuild/run_canarytest.sh
+++ b/tests/codebuild/run_canarytest.sh
@@ -8,22 +8,13 @@ function cleanup {
     # We want to run every command in this function, even if some fail.
     set +e
 
-    # Describe, if the test fails the Additional field might have more helpful info.
-    # This is helpful for nonEphemeral cluster since we are not printing manager pod logs
-    echo "Job descriptions:"
-    kubectl describe TrainingJob
-    kubectl describe ProcessingJob
-    kubectl describe HyperparameterTuningJob
-    kubectl describe BatchTransformJob
-    kubectl describe HostingDeployment
-    kubectl describe HostingAutoscalingPolicy
+    # Managable to print logs for ephemeral cluster
+    get_manager_logs
 
     delete_all_resources "default"
 
     if [ -z "${USE_EXISTING_CLUSTER}" ]
     then
-        # Managable to print logs for ephemeral cluster
-        get_manager_logs
         # Delete the role associated with the cluster thats being deleted
         delete_generated_role "${role_name}"
         # Tear down the cluster if we set it up.


### PR DESCRIPTION
### What does this PR do / how does this improve the operators?
Prints manager logs for cluster before resource deletion and before checking if USE_EXISTING_CLUSTER is false
### Special notes for the reviewer:

### Does this PR require changes to documentation?
No
### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you written or refactored unit tests to cover the change?
* [x] Have you ran all unit tests and ensured they are passing?
* [x] Have you manually tested each feature that is being added/modified?
* [x] Have you ensured you have not introduced linting errors?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.