### PR TITLE
Fix Error reconciling customizedMetricSpecification HostingAutoscalingPolicy

### DIFF
--- a/controllers/hostingautoscalingpolicy/hostingautoscalingpolicy_controller.go
+++ b/controllers/hostingautoscalingpolicy/hostingautoscalingpolicy_controller.go
@@ -18,7 +18,6 @@ package hostingautoscalingpolicy
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	commonv1 "github.com/aws/amazon-sagemaker-operator-for-k8s/api/v1/common"
@@ -434,11 +433,6 @@ func (r *Reconciler) applyAutoscalingPolicy(ctx reconcileRequestContext) ([]*app
 	var err error
 	if scalableTargetDescriptionList, scalingPolicyDescriptionList, err = r.describeAutoscalingPolicy(ctx); err != nil {
 		return scalableTargetDescriptionList, scalingPolicyDescriptionList, r.updateStatusAndReturnError(ctx, errors.Wrap(err, "Unable to describe HostingAutoscalingPolicy."))
-	}
-
-	// TODO mbaijal: This check is not needed since the first describe is handled differently
-	if len(scalableTargetDescriptionList) == 0 || len(scalingPolicyDescriptionList) == 0 {
-		return nil, nil, fmt.Errorf("hosting autoscaling policy was not applied, description is empty")
 	}
 
 	return scalableTargetDescriptionList, scalingPolicyDescriptionList, nil


### PR DESCRIPTION
### What does this PR do / how does this improve the operators?

Get rid of the check that fails HAP to be reconciled with Sagemaker resources.

### Which issue(s) does this PR fix? 

Fixes #185 

### Special notes for the reviewer:

This seems like a straightforward fix - I couldn't figure out why this block of code was still there, with a TODO to be removed, but removing it definitely fixes the issue.

### Does this PR require changes to documentation?\

No

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you written or refactored unit tests to cover the change?
* [X] Have you ran all unit tests and ensured they are passing?
* [X] Have you manually tested each feature that is being added/modified?
* [X] Have you ensured you have not introduced linting errors?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.