### PR TITLE
Fix misleading sample policyName

### DIFF
--- a/samples/hap-custom-metric.yaml
+++ b/samples/hap-custom-metric.yaml
@@ -7,7 +7,7 @@ spec:
       - endpointName: Endpoint-20200410010239-FZFY
         variantName: variant-name-1
     region: us-east-2
-    policyName: SageMakerEndpointInvocationScalingPolicy
+    policyName: CPUUtilizationScalingPolicy
     policyType: TargetTrackingScaling
     minCapacity: 1
     maxCapacity: 2


### PR DESCRIPTION
### What does this PR do / how does this improve the operators?

Change the sample manifest for using custom metrics scaling policy name, which causes scaling policy to be applied to default (invocation) type instead of the intended custom cloudwatch metric.

### Which issue(s) does this PR fix?

Fixes #185 

### Special notes for the reviewer:

### Does this PR require changes to documentation?

No

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you written or refactored unit tests to cover the change?
* [X] Have you ran all unit tests and ensured they are passing?
* [X] Have you manually tested each feature that is being added/modified?
* [X] Have you ensured you have not introduced linting errors?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.