### PR TITLE
Update EKS Cluster Version to 1.21

### DIFF
--- a/tests/codebuild/run_canarytest.sh
+++ b/tests/codebuild/run_canarytest.sh
@@ -37,7 +37,7 @@ source ./common.sh
 # Build environment `Docker image` has all prerequisite setup and credentials are being passed using AWS system manager
 
 CLUSTER_REGION=${CLUSTER_REGION:-us-east-1}
-CLUSTER_VERSION=1.17
+CLUSTER_VERSION=1.21
 
 # Define the list of optional subnets for the EKS test cluster
 CLUSTER_PUBLIC_SUBNETS=${CLUSTER_PUBLIC_SUBNETS:-}

--- a/tests/codebuild/run_integtest.sh
+++ b/tests/codebuild/run_integtest.sh
@@ -74,7 +74,7 @@ if [ "${need_setup_cluster}" == "true" ]; then
     readonly cluster_region="us-east-1"
 
     # By default eksctl picks random AZ, which time to time leads to capacity issue.
-    eksctl create cluster "${cluster_name}" --timeout=40m --region "${cluster_region}" --zones us-east-1a,us-east-1b,us-east-1c --auto-kubeconfig --version=1.17 --fargate
+    eksctl create cluster "${cluster_name}" --timeout=40m --region "${cluster_region}" --zones us-east-1a,us-east-1b,us-east-1c --auto-kubeconfig --version=1.21 --fargate
     eksctl create fargateprofile --namespace "${crd_namespace}" --cluster "${cluster_name}" --name namespace-profile --region "${cluster_region}"
     eksctl create fargateprofile --namespace "${default_operator_namespace}" --cluster "${cluster_name}" --name operator-profile --region "${cluster_region}"
 


### PR DESCRIPTION
### What does this PR do / how does this improve the operators?
Cluster Version 1.17 is now deprecated causing test pipelines to fail 
Link - https://github.com/aws/containers-roadmap/issues/1448

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.