### PR TITLE
Randomize k8s object names

### DIFF
--- a/tests/codebuild/common.sh
+++ b/tests/codebuild/common.sh
@@ -6,10 +6,19 @@ default_operator_namespace="sagemaker-k8s-operator-system"
 # Parameter:
 #    $1: Target namespace
 #    $2: Filename of the test
+#    $3: Optional spec field to rename with a random variable
 function run_test()
 {
   local target_namespace="$1"
   local file_name="$2"
+  
+  if [ $# -eq 4 ]; then
+    local replace_string="$3"
+    local random_trail="$4"
+    local random_string="$replace_string-$random_trail"
+
+    sed -i "s/$replace_string/$random_string/g" "$file_name"
+  fi
 
   kubectl apply -n "$target_namespace" -f "$file_name"
 }

--- a/tests/codebuild/create_tests.sh
+++ b/tests/codebuild/create_tests.sh
@@ -3,6 +3,9 @@
 source common.sh
 source inject_tests.sh
 
+# Use the current PID as random string
+RANDOM_STRING=$$
+
 # Applies each of the resources needed for the canary tests.
 # Parameter:
 #    $1: Namespace of the CRD
@@ -14,7 +17,7 @@ function run_canary_tests
   inject_all_variables
 
   echo "Starting Canary Tests"
-  run_test "${crd_namespace}" testfiles/xgboost-mnist-trainingjob.yaml
+  run_test "${crd_namespace}" testfiles/xgboost-mnist-trainingjob.yaml xgboost-mnist "${RANDOM_STRING}"
   run_test "${crd_namespace}" testfiles/kmeans-mnist-processingjob.yaml
   run_test "${crd_namespace}" testfiles/xgboost-mnist-hpo.yaml
   # Special code for batch transform till we fix issue-59
@@ -82,7 +85,7 @@ function verify_canary_tests
 {
   local crd_namespace="$1"
   echo "Verifying canary tests"
-  verify_test "${crd_namespace}" TrainingJob xgboost-mnist 20m Completed
+  verify_test "${crd_namespace}" TrainingJob "xgboost-mnist-${RANDOM_STRING}" 20m Completed
   verify_test "${crd_namespace}" ProcessingJob kmeans-mnist 20m Completed
   verify_test "${crd_namespace}" HyperparameterTuningJob xgboost-mnist-hpo 20m Completed
   verify_test "${crd_namespace}" BatchTransformJob xgboost-batch 20m Completed 


### PR DESCRIPTION
### What does this PR do / how does this improve the operators?
This PR improves the integ tests to randomize the k8s object names of the jobs created

### Which issue(s) does this PR fix?
This was leading to some issues on the non-ephemeral test runs

Fixes #

### Special notes for the reviewer:
Currently only applied to the trainingjob, we can expand to other jobs if we think it is required. Code is written so this can be done easily. 

### Testing
Tested by running on the pipeline. trainingjob completes successfully, we will know more only when merged and runs on the non ephemeral clusters. The pipeline is still failing but with a different error. 

### Does this PR require changes to documentation?
No

### All Submissions:

* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you written or refactored unit tests to cover the change?
* [ ] Have you ran all unit tests and ensured they are passing?
* [ ] Have you manually tested each feature that is being added/modified?
* [ ] Have you ensured you have not introduced linting errors?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.