### PR TITLE
Force Delete HPO Training Jobs

### DIFF
--- a/tests/codebuild/common.sh
+++ b/tests/codebuild/common.sh
@@ -54,6 +54,19 @@ function wait_for_crd_status()
   fi
 }
 
+function force_delete_training_jobs()
+{
+  training_jobs=$(kubectl get trainingjobs -ojson | jq -r '.items | .[] | .metadata.name')
+ 
+for job in $training_jobs
+do
+    echo $job
+    kubectl patch trainingjob $job -p '{"metadata":{"finalizers":null}}' --type=merge
+done
+ 
+kubectl delete trainingjob --all
+}
+
 # Cleans up all resources created during tests.
 # Parameter:
 #    $1: Namespace of CRD
@@ -68,7 +81,9 @@ function delete_all_resources()
   kubectl delete -n "$crd_namespace" hostingautoscalingpolicies --all
   kubectl delete -n "$crd_namespace" endpointconfig --all  
   kubectl delete -n "$crd_namespace" hostingdeployment --all 
-  kubectl delete -n "$crd_namespace" model --all  
+  kubectl delete -n "$crd_namespace" model --all 
+
+  force_delete_training_jobs 
 }
 
 # A helper function to generate an IAM Role name for the current cluster and specified namespace


### PR DESCRIPTION
### What does this PR do / how does this improve the operators?
Force deletes trainingjobs thus making sure that test runs complete. 

Tested: 
1. The branch on the integration test pipeline
2. Locally tested on the nonephemeral cluster that all stuck jobs get cleaned up. 





By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.