### PR TITLE
Force delete training jobs in integration test

### DIFF
--- a/tests/codebuild/common.sh
+++ b/tests/codebuild/common.sh
@@ -64,11 +64,11 @@ function force_delete_training_jobs()
  
   for job in $training_jobs
   do
-      echo $job
+      echo "Removing finalizer for ${job}"
       kubectl patch -n "$crd_namespace" trainingjob $job -p '{"metadata":{"finalizers":null}}' --type=merge
   done
    
-  kubectl delete -n "$crd_namespace" hyperparametertuningjob --all 
+  kubectl delete -n "$crd_namespace" trainingjob --all 
 }
 
 # Cleans up all resources created during tests.

--- a/tests/codebuild/common.sh
+++ b/tests/codebuild/common.sh
@@ -62,13 +62,13 @@ function force_delete_training_jobs()
   local crd_namespace="$1"
   training_jobs=$(kubectl get trainingjobs -n "$crd_namespace" -ojson | jq -r '.items | .[] | .metadata.name')
  
-for job in $training_jobs
-do
-    echo $job
-    kubectl patch -n "$crd_namespace" trainingjob $job -p '{"metadata":{"finalizers":null}}' --type=merge
-done
- 
-kubectl delete -n "$crd_namespace" hyperparametertuningjob --all 
+  for job in $training_jobs
+  do
+      echo $job
+      kubectl patch -n "$crd_namespace" trainingjob $job -p '{"metadata":{"finalizers":null}}' --type=merge
+  done
+   
+  kubectl delete -n "$crd_namespace" hyperparametertuningjob --all 
 }
 
 # Cleans up all resources created during tests.

--- a/tests/codebuild/common.sh
+++ b/tests/codebuild/common.sh
@@ -54,6 +54,19 @@ function wait_for_crd_status()
   fi
 }
 
+function force_delete_training_jobs()
+{
+  training_jobs=$(kubectl get trainingjobs -ojson | jq -r '.items | .[] | .metadata.name')
+ 
+for job in $training_jobs
+do
+    echo $job
+    kubectl patch trainingjob $job -p '{"metadata":{"finalizers":null}}' --type=merge
+done
+ 
+kubectl delete trainingjob --all
+}
+
 # Cleans up all resources created during tests.
 # Parameter:
 #    $1: Namespace of CRD
@@ -68,7 +81,9 @@ function delete_all_resources()
   kubectl delete -n "$crd_namespace" hostingautoscalingpolicies --all
   kubectl delete -n "$crd_namespace" endpointconfig --all  
   kubectl delete -n "$crd_namespace" hostingdeployment --all 
-  kubectl delete -n "$crd_namespace" model --all  
+  kubectl delete -n "$crd_namespace" model --all 
+
+  force_delete_training_jobs 
 }
 
 # A helper function to generate an IAM Role name for the current cluster and specified namespace

--- a/tests/codebuild/common.sh
+++ b/tests/codebuild/common.sh
@@ -87,8 +87,7 @@ function delete_all_resources()
   kubectl delete -n "$crd_namespace" model --all
 
   kubectl delete -n "$crd_namespace" trainingjob --all --timeout=3m
-  deleted_suceeded=$?
-  if [ $deleted_suceeded = 1 ]; then
+  if [ $? -ne 0 ]; then
     echo "Delete failed, will need to force delete"
   fi
 

--- a/tests/codebuild/common.sh
+++ b/tests/codebuild/common.sh
@@ -69,7 +69,6 @@ do
 done
  
 kubectl delete -n "$crd_namespace" hyperparametertuningjob --all 
-kubectl delete -n "$crd_namespace" hyperparametertuningjob --all 
 }
 
 # Cleans up all resources created during tests.
@@ -78,7 +77,7 @@ kubectl delete -n "$crd_namespace" hyperparametertuningjob --all
 function delete_all_resources()
 {
   local crd_namespace="$1"
-  kubectl delete -n "$crd_namespace" hyperparametertuningjob --all 
+  kubectl delete -n "$crd_namespace" hyperparametertuningjob --all --timeout=10m
   kubectl delete -n "$crd_namespace" trainingjob --all
   kubectl delete -n "$crd_namespace" processingjob --all
   kubectl delete -n "$crd_namespace" batchtransformjob --all

--- a/tests/codebuild/common.sh
+++ b/tests/codebuild/common.sh
@@ -77,15 +77,20 @@ kubectl delete -n "$crd_namespace" hyperparametertuningjob --all
 function delete_all_resources()
 {
   local crd_namespace="$1"
-  kubectl delete -n "$crd_namespace" hyperparametertuningjob --all --timeout=10m
-  kubectl delete -n "$crd_namespace" trainingjob --all
+  kubectl delete -n "$crd_namespace" hyperparametertuningjob --all
   kubectl delete -n "$crd_namespace" processingjob --all
   kubectl delete -n "$crd_namespace" batchtransformjob --all
   # HAP must be deleted before hostingdeployment
   kubectl delete -n "$crd_namespace" hostingautoscalingpolicies --all
   kubectl delete -n "$crd_namespace" endpointconfig --all  
   kubectl delete -n "$crd_namespace" hostingdeployment --all 
-  kubectl delete -n "$crd_namespace" model --all 
+  kubectl delete -n "$crd_namespace" model --all
+
+  kubectl delete -n "$crd_namespace" trainingjob --all --timeout=3m
+  deleted_suceeded=$?
+  if [ $deleted_suceeded = 1 ]; then
+    echo "Delete failed, will need to force delete"
+  fi
 
   force_delete_training_jobs "$crd_namespace"
 }

--- a/tests/codebuild/run_all_sample_canary_tests.sh
+++ b/tests/codebuild/run_all_sample_canary_tests.sh
@@ -12,6 +12,6 @@ verify_canary_tests "default"
 run_update_canary_tests "default"
 verify_update_canary_tests "default"
 verify_feature_canary_tests "default"
-# run_smlogs_canary_tests "default"
+run_smlogs_canary_tests "default"
 delete_all_resources "default" # Delete all existing resources to re-use metadata names
-# run_delete_canary_tests "default" 
+run_delete_canary_tests "default" 

--- a/tests/codebuild/run_all_sample_canary_tests.sh
+++ b/tests/codebuild/run_all_sample_canary_tests.sh
@@ -12,6 +12,6 @@ verify_canary_tests "default"
 run_update_canary_tests "default"
 verify_update_canary_tests "default"
 verify_feature_canary_tests "default"
-run_smlogs_canary_tests "default"
+# run_smlogs_canary_tests "default"
 delete_all_resources "default" # Delete all existing resources to re-use metadata names
-run_delete_canary_tests "default" 
+# run_delete_canary_tests "default" 


### PR DESCRIPTION
### What does this PR do / how does this improve the operators?

Sometimes training jobs do not get completely deleted, this is a workaround to get rid of them for now in the canary tests.

### Which issue(s) does this PR fix?

Fixes #

### Special notes for the reviewer:

I have tested these changes via codebuild and the integ test is sucessful

### Does this PR require changes to documentation?

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you written or refactored unit tests to cover the change?
* [ ] Have you ran all unit tests and ensured they are passing?
* [ n/a] Have you manually tested each feature that is being added/modified?
* [x] Have you ensured you have not introduced linting errors?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.