### PR TITLE
fix: correct yq syntax and lock k8 version

### DIFF
--- a/tests/codebuild/run_canarytest.sh
+++ b/tests/codebuild/run_canarytest.sh
@@ -58,7 +58,7 @@ then
    [ "${CLUSTER_PRIVATE_SUBNETS}" != "" ] && eksctl_args+=( --vpc-private-subnets="${CLUSTER_PRIVATE_SUBNETS}" )
    
    eksctl create cluster "${cluster_name}" "${eksctl_args[@]}" --dry-run > generated-cluster.yaml
-   yq w -i ".managedNodeGroups[0].disableIMDSv1 = true" generated-cluster.yaml
+   yq w -i generated-cluster.yaml managedNodeGroups[0].disableIMDSv1 true
 
    eksctl create cluster -f generated-cluster.yaml --auto-kubeconfig --timeout=40m
 


### PR DESCRIPTION
### What does this PR do / how does this improve the operators?

This PR corrects the yq syntax in the canary test. I was able to test the PR out on my machine and the relevant parts work.

### Special notes for the reviewer:

### Does this PR require changes to documentation?

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you written or refactored unit tests to cover the change?
* [ ] Have you ran all unit tests and ensured they are passing?
* [x] Have you manually tested each feature that is being added/modified?
* [x] Have you ensured you have not introduced linting errors?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.